### PR TITLE
Sprint 1: Pundit authorization layer + Community::LikesController

### DIFF
--- a/app/controllers/aurelius_press/community/likes_controller.rb
+++ b/app/controllers/aurelius_press/community/likes_controller.rb
@@ -1,5 +1,5 @@
-class AureliusPress::Community::LikesController < ApplicationController
-  before_action :authenticate_user!
+class AureliusPress::Community::LikesController < AureliusPress::ApplicationController
+  before_action :set_like, only: [ :destroy ]
 
   def create
     @likeable = GlobalID::Locator.locate(params[:like][:likeable_gid])
@@ -7,8 +7,8 @@ class AureliusPress::Community::LikesController < ApplicationController
       user: current_user,
       likeable: @likeable
     )
+    authorize @like, :create?, policy_class: AureliusPress::Community::LikePolicy
 
-    # Toggle if same state, otherwise update
     if @like.state == params[:like][:state]
       @like.state = :no_reaction
     else
@@ -18,25 +18,36 @@ class AureliusPress::Community::LikesController < ApplicationController
     if @like.save
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_back fallback_location: root_path }
+        format.html { redirect_back fallback_location: root_path, notice: "Reaction updated." }
+        format.json { render json: @like, status: :ok }
       end
     else
-      head :unprocessable_entity
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @like.errors.full_messages.to_sentence }
+        format.json { render json: @like.errors, status: :unprocessable_entity }
+      end
     end
   end
 
-  # DELETE /likes/:id
-  # Allows removing a vote completely (reset to neutral effectively, or delete record)
   def destroy
-    @like = AureliusPress::Community::Like.find(params[:id])
-    # Authorization check needed here
+    authorize @like, :destroy?, policy_class: AureliusPress::Community::LikePolicy
     @like.destroy
-    head :no_content
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path, notice: "Reaction removed." }
+      format.json { head :no_content }
+    end
   end
 
   private
 
+  def set_like
+    @like = AureliusPress::Community::Like.find(params[:id])
+  end
+
   def like_params
-    params.require(:like).permit(:user_id, :likeable_type, :likeable_id, :state)
+    params.require(:like).permit(:likeable_gid, :state)
   end
 end

--- a/app/policies/aurelius_press/catalogue/author_policy.rb
+++ b/app/policies/aurelius_press/catalogue/author_policy.rb
@@ -1,0 +1,27 @@
+class AureliusPress::Catalogue::AuthorPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin_or_above?
+  end
+
+  def update?
+    admin_or_above?
+  end
+
+  def destroy?
+    admin_or_above?
+  end
+
+  private
+
+  def admin_or_above?
+    user.present? && (user.admin? || user.superuser?)
+  end
+end

--- a/app/policies/aurelius_press/catalogue/quote_policy.rb
+++ b/app/policies/aurelius_press/catalogue/quote_policy.rb
@@ -1,0 +1,27 @@
+class AureliusPress::Catalogue::QuotePolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin_or_above?
+  end
+
+  def update?
+    admin_or_above?
+  end
+
+  def destroy?
+    admin_or_above?
+  end
+
+  private
+
+  def admin_or_above?
+    user.present? && (user.admin? || user.superuser?)
+  end
+end

--- a/app/policies/aurelius_press/catalogue/source_policy.rb
+++ b/app/policies/aurelius_press/catalogue/source_policy.rb
@@ -1,0 +1,27 @@
+class AureliusPress::Catalogue::SourcePolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin_or_above?
+  end
+
+  def update?
+    admin_or_above?
+  end
+
+  def destroy?
+    admin_or_above?
+  end
+
+  private
+
+  def admin_or_above?
+    user.present? && (user.admin? || user.superuser?)
+  end
+end

--- a/app/policies/aurelius_press/community/group_membership_policy.rb
+++ b/app/policies/aurelius_press/community/group_membership_policy.rb
@@ -1,0 +1,23 @@
+class AureliusPress::Community::GroupMembershipPolicy < ApplicationPolicy
+  def create?
+    can_write?
+  end
+
+  def destroy?
+    power_user? || record_owner?
+  end
+
+  private
+
+  def can_write?
+    user.present? && (user.user? || power_user?)
+  end
+
+  def record_owner?
+    user.present? && record.user_id == user.id
+  end
+
+  def power_user?
+    user.present? && (user.superuser? || user.admin? || user.moderator?)
+  end
+end

--- a/app/policies/aurelius_press/community/group_policy.rb
+++ b/app/policies/aurelius_press/community/group_policy.rb
@@ -1,0 +1,42 @@
+class AureliusPress::Community::GroupPolicy < ApplicationPolicy
+  def index?
+    can_write?
+  end
+
+  def show?
+    return true if power_user?
+    return false unless user.present? && (user.user? || power_user?)
+    return true if record.public_group?
+    group_creator? || member_of_group?
+  end
+
+  def create?
+    can_write?
+  end
+
+  def update?
+    power_user? || group_creator?
+  end
+
+  def destroy?
+    power_user? || group_creator?
+  end
+
+  private
+
+  def can_write?
+    user.present? && (user.user? || power_user?)
+  end
+
+  def group_creator?
+    user.present? && record.creator_id == user.id
+  end
+
+  def member_of_group?
+    user.present? && record.group_memberships.where(user: user, status: :active).exists?
+  end
+
+  def power_user?
+    user.present? && (user.superuser? || user.admin? || user.moderator?)
+  end
+end

--- a/app/policies/aurelius_press/community/like_policy.rb
+++ b/app/policies/aurelius_press/community/like_policy.rb
@@ -1,0 +1,27 @@
+class AureliusPress::Community::LikePolicy < ApplicationPolicy
+  def create?
+    can_write?
+  end
+
+  def update?
+    power_user? || record_owner?
+  end
+
+  def destroy?
+    power_user? || record_owner?
+  end
+
+  private
+
+  def can_write?
+    user.present? && (user.user? || power_user?)
+  end
+
+  def record_owner?
+    user.present? && record.user_id == user.id
+  end
+
+  def power_user?
+    user.present? && (user.superuser? || user.admin? || user.moderator?)
+  end
+end

--- a/app/policies/aurelius_press/document/content_block_policy.rb
+++ b/app/policies/aurelius_press/document/content_block_policy.rb
@@ -1,0 +1,31 @@
+class AureliusPress::Document::ContentBlockPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    power_user? || document_owner?
+  end
+
+  def update?
+    power_user? || document_owner?
+  end
+
+  def destroy?
+    power_user? || document_owner?
+  end
+
+  private
+
+  def document_owner?
+    user.present? && record.document.user_id == user.id
+  end
+
+  def power_user?
+    user.present? && (user.superuser? || user.admin? || user.moderator?)
+  end
+end

--- a/app/policies/aurelius_press/fragment/note_policy.rb
+++ b/app/policies/aurelius_press/fragment/note_policy.rb
@@ -1,10 +1,10 @@
-class AureliusPress::Fragment::CommentPolicy < ApplicationPolicy
+class AureliusPress::Fragment::NotePolicy < ApplicationPolicy
   def index?
-    authenticated_reader?
+    can_write?
   end
 
   def show?
-    authenticated_reader?
+    power_user? || record_owner?
   end
 
   def create?
@@ -23,16 +23,8 @@ class AureliusPress::Fragment::CommentPolicy < ApplicationPolicy
     def resolve
       if power_user?
         scope.all
-      elsif user.present?
-        accessible_doc_ids = AureliusPress::Document::Document
-          .where(visibility: %w[public_to_app_users public_to_www], status: :published)
-          .or(AureliusPress::Document::Document.where(user_id: user.id))
-          .pluck(:id)
-
-        scope.where(
-          commentable_type: AureliusPress::Document::Document::NAMESPACED_TYPES,
-          commentable_id: accessible_doc_ids
-        )
+      elsif user.present? && (user.user? || user.moderator? || user.admin? || user.superuser?)
+        scope.where(user: user)
       else
         scope.none
       end
@@ -46,10 +38,6 @@ class AureliusPress::Fragment::CommentPolicy < ApplicationPolicy
   end
 
   private
-
-  def authenticated_reader?
-    user.present?
-  end
 
   def can_write?
     user.present? && (user.user? || power_user?)

--- a/app/policies/aurelius_press/taxonomy/category_policy.rb
+++ b/app/policies/aurelius_press/taxonomy/category_policy.rb
@@ -1,0 +1,27 @@
+class AureliusPress::Taxonomy::CategoryPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin_or_above?
+  end
+
+  def update?
+    admin_or_above?
+  end
+
+  def destroy?
+    admin_or_above?
+  end
+
+  private
+
+  def admin_or_above?
+    user.present? && (user.admin? || user.superuser?)
+  end
+end

--- a/app/policies/aurelius_press/taxonomy/tag_policy.rb
+++ b/app/policies/aurelius_press/taxonomy/tag_policy.rb
@@ -1,0 +1,27 @@
+class AureliusPress::Taxonomy::TagPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin_or_above?
+  end
+
+  def update?
+    admin_or_above?
+  end
+
+  def destroy?
+    admin_or_above?
+  end
+
+  private
+
+  def admin_or_above?
+    user.present? && (user.admin? || user.superuser?)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,9 +125,7 @@ Rails.application.routes.draw do
       resources :categories, only: [ :index, :show ], param: :slug
     end
     namespace :community do
-      # Flattened Likes for ALL likeable objects
       resources :reactions, only: [ :create, :destroy, :update ]
-      # Genuine Likes (Votes)
       resources :likes, only: [ :create, :destroy, :update ]
     end
     # Define routes for users

--- a/design/backlog.md
+++ b/design/backlog.md
@@ -1,43 +1,183 @@
-# Agile Backlog: Taxonomy & API Sprint
+# AureliusPress — Implementation Backlog
 
-## Use Case Format
-"As a [user], I want to [action] so that [value]."
+> Generated: 2026-04-24  
+> Estimated overall completion at time of writing: ~60–65%
 
-## MUST HAVE (Essential for Sprint success)
-### 1. Catalogue TDD Audit
-- **Use Case**: As a Developer, I want full test coverage for all Catalogue models so that the codebase is stable and regression-free.
-- **Acceptance Criteria**:
-    - [ ] `Author` model spec covers `ordered`, `with_quotes`, `with_affiliate_links` scopes and `bio_summary`.
-    - [ ] `Quote` model spec covers `source_authors` delegation and `sluggable_text` generation.
-    - [ ] `Source` model spec covers `ordered_by_title` and `ordered_by_type` scopes.
+Items are ordered by dependency — foundational work first, user-facing features after, polish last.
 
-### 2. Internal Taxonomy API (Search)
-- **Use Case**: As an Admin, I want to search tags and categories as I type so that I can quickly assign metadata to content.
-- **Acceptance Criteria**:
-    - [ ] `GET /aurelius-press/api/v1/taxonomy/tags?q=[query]` returns JSON of matching tags.
-    - [ ] `GET /aurelius-press/api/v1/taxonomy/categories?q=[query]` returns JSON of matching categories.
-    - [ ] API is versioned and secured for admin access.
+---
 
-### 3. Hotwire Taxonomy Search-Select
-- **Use Case**: As an Admin, I want a unified search-select UI for taxonomy so that I don't have to toggle between static selects and text inputs.
-- **Acceptance Criteria**:
-    - [ ] Stimulus controller debounces search requests to the API.
-    - [ ] Clicking a result adds it to the selection.
-    - [ ] Hitting 'Enter' with a non-existent tag creates it via the API and selects it.
+## Phase 1 — Authorization Foundation (Pundit Policies)
 
-## SHOULD HAVE (Significant value)
-### 4. Public Quote API V1
-- **Use Case**: As a Public User/Consumer, I want a JSON interface for the Quote catalogue so that I can integrate stoic wisdom into other apps.
-- **Acceptance Criteria**:
-    - [ ] `GET /aurelius-press/api/v1/catalogue/quotes` returns paginated JSON.
-    - [ ] Response includes nested Source and Author data.
+Must come first: controllers downstream depend on policies being in place.
 
-## COULD HAVE (Desired but not critical)
-### 5. Advanced Search Filters
-- **Use Case**: As a Public User, I want to filter the Quote API by author or category so that I can find specific wisdom.
-- **Acceptance Criteria**:
-    - [ ] API supports `?author=[slug]` and `?category=[slug]` filters.
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 1.1 | `AureliusPress::Fragment::CommentPolicy` | Critical | Covers public & admin comment access |
+| 1.2 | `AureliusPress::Fragment::NotePolicy` | Critical | Covers public & admin note access |
+| 1.3 | `AureliusPress::Community::LikePolicy` | Critical | Scope create/destroy to authenticated users |
+| 1.4 | `AureliusPress::Community::GroupPolicy` | High | Group visibility + membership rules |
+| 1.5 | `AureliusPress::Community::GroupMembershipPolicy` | High | Join/leave permissions |
+| 1.6 | `AureliusPress::Catalogue::AuthorPolicy` | High | Public read; admin write |
+| 1.7 | `AureliusPress::Catalogue::SourcePolicy` | High | Public read; admin write |
+| 1.8 | `AureliusPress::Catalogue::QuotePolicy` | High | Public read; admin write |
+| 1.9 | `AureliusPress::Document::ContentBlockPolicy` | High | Owner/group write; public read |
+| 1.10 | `AureliusPress::Taxonomy::TagPolicy` | Medium | Admin CRUD; public read |
+| 1.11 | `AureliusPress::Taxonomy::CategoryPolicy` | Medium | Admin CRUD; public read |
 
-## WON'T HAVE (This time)
-- **6. Write access for Public API**: No POST/PUT/DELETE for the public catalogue.
-- **7. Global Site Search**: This sprint is focused specifically on taxonomy lookups and the catalogue API.
+---
+
+## Phase 2 — Public Comments & Notes (Controllers + Views)
+
+Depends on Phase 1 policies. Implement public-facing interaction layer.
+
+### 2a — Document Comments (nested under each document type)
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 2.1 | `AureliusPress::Document::AtomicBlogPosts::CommentsController` | High | `index`, `create`, `destroy` |
+| 2.2 | `AureliusPress::Document::BlogPosts::CommentsController` | High | `index`, `create`, `destroy` |
+| 2.3 | `AureliusPress::Document::Pages::CommentsController` | High | `index`, `create`, `destroy` |
+| 2.4 | Views: comment form partial + comment list partial (shared) | High | Reuse across document types |
+| 2.5 | Turbo Stream responses for comment create/destroy | High | Inline update without full page reload |
+
+### 2b — Document Notes (nested under each document type)
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 2.6 | `AureliusPress::Document::AtomicBlogPosts::NotesController` | High | `index`, `create`, `destroy` |
+| 2.7 | `AureliusPress::Document::BlogPosts::NotesController` | High | `index`, `create`, `destroy` |
+| 2.8 | `AureliusPress::Document::Pages::NotesController` | High | `index`, `create`, `destroy` |
+| 2.9 | Views: note form partial + note list partial (shared) | High | Reuse across document types |
+
+### 2c — Content Block Comments & Notes
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 2.10 | `AureliusPress::Document::BlogPosts::ContentBlocks::CommentsController` | Medium | Inline block-level comments |
+| 2.11 | `AureliusPress::Document::BlogPosts::ContentBlocks::NotesController` | Medium | Inline block-level notes |
+| 2.12 | Views: inline comment/note partials for content blocks | Medium | |
+
+### 2d — Catalogue Comments & Notes
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 2.13 | `AureliusPress::Catalogue::Authors::CommentsController` | Medium | |
+| 2.14 | `AureliusPress::Catalogue::Sources::CommentsController` | Medium | |
+| 2.15 | `AureliusPress::Catalogue::Quotes::CommentsController` | Medium | |
+| 2.16 | `AureliusPress::Catalogue::Authors::NotesController` | Medium | |
+| 2.17 | `AureliusPress::Catalogue::Sources::NotesController` | Medium | |
+| 2.18 | `AureliusPress::Catalogue::Quotes::NotesController` | Medium | |
+| 2.19 | Views for catalogue comments/notes | Medium | |
+
+---
+
+## Phase 3 — JournalEntry Document Type
+
+`JournalEntry` is defined as an STI type but has no controller, views, or tests.
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 3.1 | `AureliusPress::Document::JournalEntriesController` | High | Full CRUD (private by default) |
+| 3.2 | Views: index, show, new, edit, _form partial | High | |
+| 3.3 | `JournalEntry`-specific validations & business rules | High | e.g. always private, no publishing |
+| 3.4 | Nested content blocks for JournalEntry (if applicable) | Medium | Reuse existing content block system |
+| 3.5 | Nested comments/notes for JournalEntry | Medium | Depends on Phase 2 |
+
+---
+
+## Phase 4 — Group Memberships UI
+
+Model and associations exist; routes are commented out.
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 4.1 | Uncomment `resources :group_memberships` in routes.rb | High | |
+| 4.2 | `AureliusPress::Community::GroupMembershipsController` | High | `create`, `destroy` (join/leave) |
+| 4.3 | Views: group membership UI (join/leave buttons) | High | Turbo Stream for instant feedback |
+| 4.4 | Group show page: list members | Medium | |
+| 4.5 | Group index page: discoverable groups | Medium | |
+
+---
+
+## Phase 5 — Likes System Completion
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 5.1 | Implement `LikesController#update` | High | Route exists but action is missing |
+| 5.2 | Verify Turbo Stream responses for like/unlike on all likeable types | High | Documents, content blocks, fragments |
+| 5.3 | Like count display on public views | Medium | |
+
+---
+
+## Phase 6 — Admin Settings Panel
+
+Currently fully commented out (`resources :settings` in routes).
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 6.1 | Define settings scope: what is configurable? | High | Decide before implementing |
+| 6.2 | `AureliusPress::Admin::SettingsController` | Medium | |
+| 6.3 | Settings model / store (e.g. `RailsSettings` gem or custom) | Medium | |
+| 6.4 | Admin settings views | Medium | |
+
+---
+
+## Phase 7 — Soft Deletion
+
+Noted as a `@todo` in the admin Comments and Notes controllers.
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 7.1 | Add `discarded_at` / `deleted_at` to `fragments` table | Medium | Migration required |
+| 7.2 | Integrate `discard` gem (or equivalent) on `Fragment` | Medium | |
+| 7.3 | Update admin moderation controllers to use soft delete | Medium | |
+| 7.4 | Filter soft-deleted fragments from public queries | Medium | |
+
+---
+
+## Phase 8 — Test Coverage Gaps
+
+Fill gaps in parallel with feature work above (each phase should ship with tests).
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 8.1 | Policy specs for all new Pundit policies (Phase 1) | Critical | Write alongside policies |
+| 8.2 | Feature specs: public comment create/destroy (Phase 2) | High | |
+| 8.3 | Feature specs: public note create/destroy (Phase 2) | High | |
+| 8.4 | Feature specs: JournalEntry CRUD (Phase 3) | High | |
+| 8.5 | Feature specs: group membership join/leave (Phase 4) | High | |
+| 8.6 | Feature specs: public catalogue items (authors/sources/quotes) | Medium | Read-only but currently untested |
+| 8.7 | Controller specs: all new controllers from Phases 2–5 | Medium | |
+| 8.8 | Routing specs: newly uncommented routes (Phase 4) | Medium | |
+| 8.9 | Feature specs: likes on all resource types | Medium | |
+| 8.10 | Feature specs: admin settings (Phase 6) | Low | |
+
+---
+
+## Phase 9 — Polish & Non-Functional
+
+| # | Item | Priority | Notes |
+|---|---|---|---|
+| 9.1 | Pagination on admin index actions (noted in controller `@todo`) | Medium | |
+| 9.2 | `JournalEntry` privacy enforcement (always private) | Medium | Policy + model validation |
+| 9.3 | `README.md` — replace boilerplate with real project docs | Low | |
+| 9.4 | Reactions feature decision | Low | Routes commented out; decide keep/remove |
+| 9.5 | SimpleCov coverage target enforcement in CI | Low | |
+
+---
+
+## Summary
+
+| Phase | Focus | Items | Est. Effort |
+|---|---|---|---|
+| 1 | Pundit Policies | 11 | ~2 days |
+| 2 | Public Comments & Notes | 19 | ~4–5 days |
+| 3 | JournalEntry | 5 | ~2 days |
+| 4 | Group Memberships UI | 5 | ~1.5 days |
+| 5 | Likes Completion | 3 | ~0.5 days |
+| 6 | Admin Settings | 4 | ~2 days |
+| 7 | Soft Deletion | 4 | ~1 day |
+| 8 | Test Coverage | 10 | ~3 days |
+| 9 | Polish | 5 | ~1 day |
+| **Total** | | **66** | **~17–18 days** |

--- a/design/sprint_1.md
+++ b/design/sprint_1.md
@@ -1,0 +1,102 @@
+# Sprint 1 Plan — AureliusPress
+
+**Dates:** 2026-04-27 — 2026-05-08 (2 weeks)  
+**Team:** 1 engineer (solo)  
+**Sprint Goal:** Establish the full Pundit authorization layer and complete the Likes system so that every subsequent feature can be built on a secure, tested policy foundation.
+
+---
+
+## Capacity
+
+| Person | Available Days | Est. Points | Notes |
+|--------|---------------|-------------|-------|
+| Paul | 8 of 10 | 16 pts | 80% capacity; 2-pt buffer for interrupts |
+| **Total** | **8** | **16 pts** | 1 pt ≈ ~half day |
+
+> **Buffer rule:** Plan to 16 pts. First stretch item cut if blocked.
+
+---
+
+## Sprint Backlog
+
+### P0 — Must Ship (unblocks everything downstream)
+
+| # | Item | Pts | Dependencies | Backlog Ref |
+|---|---|---|---|---|
+| S1-01 | `AureliusPress::Fragment::CommentPolicy` + policy spec | 2 | None | 1.1, 8.1 |
+| S1-02 | `AureliusPress::Fragment::NotePolicy` + policy spec | 2 | None | 1.2, 8.1 |
+| S1-03 | `AureliusPress::Community::LikePolicy` + policy spec | 1 | None | 1.3, 8.1 |
+| S1-04 | `AureliusPress::Community::GroupPolicy` + policy spec | 1 | None | 1.4, 8.1 |
+| S1-05 | `AureliusPress::Community::GroupMembershipPolicy` + policy spec | 1 | S1-04 | 1.5, 8.1 |
+| S1-06 | `AureliusPress::Catalogue::AuthorPolicy` + policy spec | 1 | None | 1.6, 8.1 |
+| S1-07 | `AureliusPress::Catalogue::SourcePolicy` + policy spec | 1 | None | 1.7, 8.1 |
+| S1-08 | `AureliusPress::Catalogue::QuotePolicy` + policy spec | 1 | None | 1.8, 8.1 |
+| S1-09 | `AureliusPress::Document::ContentBlockPolicy` + policy spec | 1 | None | 1.9, 8.1 |
+
+**P0 Total: 11 pts**
+
+### P1 — Should Ship (high value, no blockers)
+
+| # | Item | Pts | Dependencies | Backlog Ref |
+|---|---|---|---|---|
+| S1-10 | Implement `LikesController#update` action | 1 | S1-03 (LikePolicy) | 5.1 |
+| S1-11 | Verify Turbo Stream responses for like/unlike across all likeable types | 1 | S1-10 | 5.2 |
+| S1-12 | Like count display on public document/block views | 1 | S1-11 | 5.3 |
+
+**P1 Total: 3 pts**
+
+### P2 — Stretch (cut if P0/P1 runs long)
+
+| # | Item | Pts | Dependencies | Backlog Ref |
+|---|---|---|---|---|
+| S1-13 | `AureliusPress::Taxonomy::TagPolicy` + policy spec | 1 | None | 1.10, 8.1 |
+| S1-14 | `AureliusPress::Taxonomy::CategoryPolicy` + policy spec | 1 | None | 1.11, 8.1 |
+
+**P2 Total: 2 pts**
+
+---
+
+## Planned Capacity: 16 pts | Sprint Load: 16 pts (100% — P2 is the buffer)
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Policy scope ambiguity (what can a Group member see?) | Slows S1-04/S1-05 | Review `GroupMembership` model + existing admin policies first; make a decision and document it |
+| `LikesController#update` route may have unintended semantics (toggle vs. explicit) | S1-10 breaks existing likes | Read existing `create`/`destroy` actions and the route definition before implementing; write a failing test first |
+| Policy specs reveal missing factories | Slows all policy work | Check FactoryBot coverage for Catalogue/Community models before starting; add factories same-day if missing |
+
+---
+
+## Definition of Done
+
+- [ ] Each policy has a corresponding `*_policy_spec.rb` with coverage for all roles (guest, authenticated user, owner, admin)
+- [ ] All new specs are green (`bundle exec rspec spec/policies`)
+- [ ] `LikesController#update` covered by a feature spec
+- [ ] No Rubocop offences introduced (`bundle exec rubocop --format progress`)
+- [ ] Brakeman clean (`bundle exec brakeman -q`)
+- [ ] PR opened against `master` with description referencing sprint items
+
+---
+
+## Key Dates
+
+| Date | Event |
+|------|-------|
+| 2026-04-27 (Mon) | Sprint start — begin P0 policy work |
+| 2026-04-30 (Thu) | Mid-sprint check-in — P0 should be ~75% done |
+| 2026-05-06 (Wed) | Code freeze for P0/P1 |
+| 2026-05-07 (Thu) | PR review + polish |
+| 2026-05-08 (Fri) | Sprint end / demo / retro |
+
+---
+
+## Sprint 2 Preview (what this unlocks)
+
+With policies in place, Sprint 2 can immediately begin:
+- Public Comments controllers + views (backlog 2.1–2.5)
+- Public Notes controllers + views (backlog 2.6–2.9)
+- JournalEntry controller + views (backlog 3.1–3.3)
+- Group Memberships UI (backlog 4.1–4.3)

--- a/design/testing_strategy.md
+++ b/design/testing_strategy.md
@@ -1,0 +1,487 @@
+# AureliusPress — Testing Strategy
+
+> Generated: 2026-04-24  
+> Stack: Rails 7.2 · RSpec · FactoryBot · Capybara (Firefox headless) · Pundit · DatabaseCleaner · Shoulda Matchers · Devise test helpers
+
+---
+
+## 1. Test Pyramid
+
+```
+         ┌─────────────────────────┐
+         │     Feature / E2E       │  ~20%  Capybara + Selenium, :js, slow
+         │  (Capybara + Selenium)  │        Golden path + access control
+         ├─────────────────────────┤
+         │    Request / Controller │  ~25%  HTTP layer, auth, redirects
+         │       (RSpec request)   │        No JS, fast
+         ├─────────────────────────┤
+         │      Policy Specs       │  ~15%  Pundit rules, all roles
+         │   (RSpec, type: :policy)│        Pure Ruby, very fast
+         ├─────────────────────────┤
+         │       Model / Unit      │  ~40%  Validations, associations, scopes
+         │   (RSpec, type: :model) │        Pure Ruby, fastest
+         └─────────────────────────┘
+```
+
+**Guiding principle:** Push logic as far down the pyramid as possible. A Pundit rule belongs in a policy spec, not a feature spec. A visibility scope belongs in a model spec, not a request spec. Feature specs exist only to prove the UI wires everything together.
+
+---
+
+## 2. Existing Test Infrastructure — Key Conventions
+
+Before adding any tests, know what's already set up in `spec/rails_helper.rb`:
+
+| Convention | Detail |
+|---|---|
+| **JS driver** | Firefox headless via `Capybara.register_driver :selenium_headless` |
+| **JS metadata** | Tag examples with `:js` — this also switches DatabaseCleaner to `:truncation` |
+| **Non-JS default** | DatabaseCleaner uses `:transaction` (rolls back after each example — fast) |
+| **Auth helpers** | `sign_in` / `sign_out` via `Devise::Test::IntegrationHelpers` in feature/request specs |
+| **FactoryBot guard** | `create_list` is capped at 3 records — never exceed this |
+| **Role factories** | `create(:aurelius_press_user)`, `:aurelius_press_moderator_user`, `:aurelius_press_admin_user`, `:aurelius_press_superuser_user` |
+| **Focus tag** | `:focus` metadata runs only those examples — remember to remove before committing |
+
+---
+
+## 3. Policy Testing (Phase 1 — Sprint 1 Priority)
+
+### 3a. Setup
+
+Create `spec/policies/` directory. Each policy file mirrors `app/policies/`:
+
+```
+spec/policies/
+  aurelius_press/
+    fragment/
+      comment_policy_spec.rb
+      note_policy_spec.rb
+    community/
+      like_policy_spec.rb
+      group_policy_spec.rb
+      group_membership_policy_spec.rb
+    catalogue/
+      author_policy_spec.rb
+      source_policy_spec.rb
+      quote_policy_spec.rb
+    document/
+      content_block_policy_spec.rb
+    taxonomy/
+      tag_policy_spec.rb
+      category_policy_spec.rb
+```
+
+Add to `spec/rails_helper.rb` (if not already present):
+```ruby
+require "pundit/rspec"
+```
+
+### 3b. Policy Spec Template
+
+Use this structure for every new policy. The `DocumentPolicy` is the gold standard — follow its role ladder.
+
+```ruby
+# spec/policies/aurelius_press/fragment/comment_policy_spec.rb
+require "rails_helper"
+
+RSpec.describe AureliusPress::Fragment::CommentPolicy, type: :policy do
+  subject(:policy) { described_class.new(actor, comment) }
+
+  # Shared setup — create the record owner separately so ownership tests
+  # don't accidentally pass for the wrong reason.
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:reader)     { create(:aurelius_press_reader_user) }
+  let(:moderator)  { create(:aurelius_press_moderator_user) }
+  let(:admin)      { create(:aurelius_press_admin_user) }
+  let(:superuser)  { create(:aurelius_press_superuser_user) }
+
+  let(:commentable) { create(:aurelius_press_document_blog_post) }
+  let(:comment)     { create(:aurelius_press_fragment_comment, user: owner, commentable: commentable) }
+
+  # ── Guest (unauthenticated) ───────────────────────────────────────────────
+  context "when actor is a guest (nil)" do
+    let(:actor) { nil }
+    it { is_expected.to forbid_action(:index)   }
+    it { is_expected.to forbid_action(:show)    }
+    it { is_expected.to forbid_action(:create)  }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+
+  # ── Reader ────────────────────────────────────────────────────────────────
+  context "when actor is a reader" do
+    let(:actor) { reader }
+    it { is_expected.to permit_action(:index)   }
+    it { is_expected.to permit_action(:show)    }
+    it { is_expected.to forbid_action(:create)  }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+
+  # ── Regular user (not owner) ──────────────────────────────────────────────
+  context "when actor is an authenticated user who does NOT own the comment" do
+    let(:actor) { other_user }
+    it { is_expected.to permit_action(:index)   }
+    it { is_expected.to permit_action(:show)    }
+    it { is_expected.to permit_action(:create)  }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+
+  # ── Owner ─────────────────────────────────────────────────────────────────
+  context "when actor is the comment owner" do
+    let(:actor) { owner }
+    it { is_expected.to permit_action(:index)   }
+    it { is_expected.to permit_action(:show)    }
+    it { is_expected.to permit_action(:create)  }
+    it { is_expected.to permit_action(:destroy) }
+  end
+
+  # ── Power users ───────────────────────────────────────────────────────────
+  [
+    [:moderator, :moderator],
+    [:admin,     :admin],
+    [:superuser, :superuser],
+  ].each do |role, let_name|
+    context "when actor is a #{role}" do
+      let(:actor) { send(let_name) }
+      it { is_expected.to permit_action(:index)   }
+      it { is_expected.to permit_action(:show)    }
+      it { is_expected.to permit_action(:create)  }
+      it { is_expected.to permit_action(:destroy) }
+    end
+  end
+
+  # ── Scope ─────────────────────────────────────────────────────────────────
+  describe "Scope" do
+    subject(:scope) { described_class::Scope.new(actor, AureliusPress::Fragment::Comment).resolve }
+
+    let!(:public_comment)  { create(:aurelius_press_fragment_comment, commentable: commentable) }
+    let!(:private_comment) { create(:aurelius_press_fragment_comment, commentable: create(:aurelius_press_document_blog_post, :private_to_owner)) }
+
+    context "when actor is a guest" do
+      let(:actor) { nil }
+      # Adjust based on your business rule — guests may see comments on public docs only
+      it "returns only comments on public documents" do
+        expect(scope).to include(public_comment)
+        expect(scope).not_to include(private_comment)
+      end
+    end
+
+    context "when actor is a superuser" do
+      let(:actor) { superuser }
+      it "returns all comments" do
+        expect(scope).to include(public_comment, private_comment)
+      end
+    end
+  end
+end
+```
+
+### 3c. Policy Rules Reference
+
+Mirror the role ladder from `DocumentPolicy` — it's already the source of truth:
+
+| Role | Can read others' | Can create | Can destroy own | Can destroy others' |
+|---|---|---|---|---|
+| Guest (nil) | public only | no | no | no |
+| Reader | public + app | no | no | no |
+| User | public + app + group | yes | yes | no |
+| Moderator | all | yes | yes | yes |
+| Admin | all | yes | yes | yes |
+| Superuser | all | yes | yes | yes |
+
+---
+
+## 4. LikesController Testing
+
+### 4a. What to Test
+
+The `LikesController` is a JSON/Turbo API — it doesn't render HTML pages, so use **request specs** (not feature specs) for the HTTP layer.
+
+```
+spec/requests/
+  aurelius_press/
+    likes_spec.rb   ← already partially exists under admin; create public one
+```
+
+### 4b. Request Spec Template
+
+```ruby
+# spec/requests/aurelius_press/likes_spec.rb
+require "rails_helper"
+
+RSpec.describe "Likes", type: :request do
+  let(:user)      { create(:aurelius_press_user) }
+  let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+
+  describe "POST /aurelius-press/likes (create)" do
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "creates a like and returns turbo stream" do
+        expect {
+          post aurelius_press_likes_path,
+               params: { like: { likeable_type: "AureliusPress::Document::BlogPost", likeable_id: blog_post.id } },
+               headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        }.to change(AureliusPress::Community::Like, :count).by(1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "is idempotent — cannot double-like" do
+        create(:aurelius_press_community_like, user: user, likeable: blog_post)
+        expect {
+          post aurelius_press_likes_path,
+               params: { like: { likeable_type: "AureliusPress::Document::BlogPost", likeable_id: blog_post.id } }
+        }.not_to change(AureliusPress::Community::Like, :count)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_likes_path,
+             params: { like: { likeable_type: "AureliusPress::Document::BlogPost", likeable_id: blog_post.id } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/likes/:id (destroy)" do
+    let!(:like) { create(:aurelius_press_community_like, user: user, likeable: blog_post) }
+
+    context "when authenticated as the like owner" do
+      before { sign_in user }
+
+      it "destroys the like" do
+        expect {
+          delete aurelius_press_like_path(like),
+                 headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        }.to change(AureliusPress::Community::Like, :count).by(-1)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in create(:aurelius_press_user) }
+
+      it "is forbidden" do
+        delete aurelius_press_like_path(like)
+        expect(response).to have_http_status(:forbidden).or redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "PATCH /aurelius-press/likes/:id (update)" do
+    # Test once update action is implemented (backlog 5.1)
+    # This is a placeholder — define expected semantics before writing this test.
+    it "is defined (route exists)" do
+      expect { patch aurelius_press_like_path(like) }.not_to raise_error(ActionController::RoutingError)
+    end
+  end
+end
+```
+
+### 4c. Feature Test for Like Toggle (UI)
+
+For the Turbo Stream visual feedback, one feature test per likeable surface is enough:
+
+```ruby
+# spec/features/aurelius_press/public/document/blog_post/likes_spec.rb
+RSpec.feature "User can like a blog post", :js do
+  let(:user)      { create(:aurelius_press_user) }
+  let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+
+  scenario "authenticated user likes and unlikes a post" do
+    sign_in user
+    visit aurelius_press_blog_post_path(blog_post)
+
+    # Like
+    click_button "Like"   # adjust selector to your actual UI
+    expect(page).to have_content("1 like")
+
+    # Unlike
+    click_button "Unlike"
+    expect(page).to have_content("0 likes")
+  end
+
+  scenario "guest cannot like a post" do
+    visit aurelius_press_blog_post_path(blog_post)
+    expect(page).not_to have_button("Like")
+  end
+end
+```
+
+---
+
+## 5. Public Comments & Notes Testing (Phase 2)
+
+### 5a. Layer Strategy
+
+| What to test | Test type | Reason |
+|---|---|---|
+| Who can create/destroy | Policy spec | Fastest; pure Ruby |
+| HTTP create/destroy + redirects | Request spec | No browser needed |
+| Comment appears in page after submit | Feature spec (:js) | Turbo Stream update needs real browser |
+| Access control (not-your-comment delete) | Request spec | Faster than feature |
+
+### 5b. Feature Test Pattern
+
+Follow the existing `crud_management_spec.rb` pattern exactly. One file per document type per fragment type:
+
+```
+spec/features/aurelius_press/public/document/
+  blog_post/
+    comments_spec.rb
+    notes_spec.rb
+  atomic_blog_post/
+    comments_spec.rb
+    notes_spec.rb
+  page/
+    comments_spec.rb
+    notes_spec.rb
+```
+
+```ruby
+# spec/features/aurelius_press/public/document/blog_post/comments_spec.rb
+require "rails_helper"
+
+RSpec.feature "User can manage comments on a Blog Post", :js do
+  let(:user)      { create(:aurelius_press_user) }
+  let(:author)    { create(:aurelius_press_user) }
+  let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www, user: author) }
+  let!(:existing_comment) { create(:aurelius_press_fragment_comment, commentable: blog_post, user: author, content: "First thought.") }
+
+  scenario "CREATE - authenticated user can post a comment" do
+    sign_in user
+    visit aurelius_press_blog_post_path(blog_post)
+    fill_in "Add a comment", with: "My new comment"
+    click_button "Post Comment"
+    expect(page).to have_content("My new comment")
+    expect(AureliusPress::Fragment::Comment.count).to eq(2)
+  end
+
+  scenario "READ - guest can read existing comments" do
+    visit aurelius_press_blog_post_path(blog_post)
+    expect(page).to have_content("First thought.")
+  end
+
+  scenario "DELETE - user can delete their own comment" do
+    sign_in user
+    my_comment = create(:aurelius_press_fragment_comment, commentable: blog_post, user: user, content: "To be deleted.")
+    visit aurelius_press_blog_post_path(blog_post)
+    accept_confirm do
+      click_link "Delete", href: aurelius_press_blog_post_comment_path(blog_post, my_comment)
+    end
+    expect(page).not_to have_content("To be deleted.")
+    expect(AureliusPress::Fragment::Comment.count).to eq(1)
+  end
+
+  scenario "DELETE - user cannot delete someone else's comment" do
+    sign_in user
+    visit aurelius_press_blog_post_path(blog_post)
+    # The delete link should not be rendered for comments the user doesn't own
+    expect(page).not_to have_link("Delete", href: aurelius_press_blog_post_comment_path(blog_post, existing_comment))
+  end
+
+  scenario "guest cannot post a comment" do
+    visit aurelius_press_blog_post_path(blog_post)
+    expect(page).not_to have_field("Add a comment")
+    expect(page).not_to have_button("Post Comment")
+  end
+end
+```
+
+### 5c. Request Spec for Comment HTTP Layer
+
+```ruby
+# spec/requests/aurelius_press/document/blog_posts/comments_spec.rb
+require "rails_helper"
+
+RSpec.describe "Blog Post Comments", type: :request do
+  let(:user)      { create(:aurelius_press_user) }
+  let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+
+  describe "POST /aurelius-press/blog-posts/:blog_post_id/comments" do
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "creates a comment and redirects" do
+        expect {
+          post aurelius_press_blog_post_comments_path(blog_post),
+               params: { comment: { content: "Test comment" } }
+        }.to change(AureliusPress::Fragment::Comment, :count).by(1)
+        expect(response).to redirect_to(aurelius_press_blog_post_path(blog_post))
+      end
+
+      it "rejects blank content" do
+        expect {
+          post aurelius_press_blog_post_comments_path(blog_post),
+               params: { comment: { content: "" } }
+        }.not_to change(AureliusPress::Fragment::Comment, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_blog_post_comments_path(blog_post),
+             params: { comment: { content: "Test" } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end
+```
+
+---
+
+## 6. Coverage Targets
+
+| Layer | Current est. | Target | How to reach |
+|---|---|---|---|
+| Models | ~90% | 95% | Add JournalEntry behavioural tests |
+| Policies | ~15% | 100% | All 11 Sprint 1 policy specs |
+| Controllers / Request | ~50% | 80% | Request specs for all new public controllers |
+| Feature (E2E) | ~40% | 70% | One CRUD feature spec per new controller |
+| Routes | ~60% | 90% | Add routing specs for newly uncommented routes |
+
+Enforce in CI via SimpleCov (already in Gemfile). Add a minimum threshold to `spec/spec_helper.rb` or `.simplecov`:
+
+```ruby
+# .simplecov
+SimpleCov.start "rails" do
+  minimum_coverage 80
+  add_filter "/spec/"
+  add_filter "/config/"
+  add_filter "/vendor/"
+end
+```
+
+---
+
+## 7. Test Execution Order & CI Guidance
+
+Run in this order to fail fast:
+
+```bash
+# 1. Fast (pure Ruby, no DB)
+bundle exec rspec spec/models spec/policies --format progress
+
+# 2. Medium (DB, no browser)
+bundle exec rspec spec/requests spec/controllers spec/routing --format progress
+
+# 3. Slow (browser required)
+bundle exec rspec spec/features --format progress
+```
+
+In CI, run all layers but cache the fast layers separately so a model failure doesn't block a 10-minute feature suite.
+
+---
+
+## 8. Test Writing Rules (Project-Specific)
+
+1. **Never mock the database** — this app already uses real DB + DatabaseCleaner. Keep it that way.
+2. **`:js` only when Turbo Streams are tested** — for plain HTML redirects, drop the `:js` tag (10× faster).
+3. **`create_list` max 3** — the FactoryBot guard in `rails_helper.rb` enforces this; it will raise if exceeded.
+4. **State reset in loops** — the existing `crud_management_spec.rb` pattern shows how to handle this: `destroy_all` + recreate at the top of the loop body. Follow it exactly.
+5. **Policy specs are pure Ruby** — no `sign_in`, no `visit`. Instantiate `described_class.new(user, record)` directly.
+6. **One feature file per resource × action group** — `blog_post/comments_spec.rb`, `blog_post/notes_spec.rb` etc. Don't combine.
+7. **Template assertions for view routing** — the existing feature specs assert `have_css("[template=\"Namespace::Controller#action\"]")`. Continue this pattern to catch routing bugs early.
+8. **Always test the guest path** — every new public controller must have at least one example asserting unauthenticated access is handled correctly.

--- a/spec/policies/aurelius_press/catalogue/author_policy_spec.rb
+++ b/spec/policies/aurelius_press/catalogue/author_policy_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Catalogue::AuthorPolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)     { nil }
+  let(:reader)    { create(:aurelius_press_reader_user) }
+  let(:user)      { create(:aurelius_press_user) }
+  let(:moderator) { create(:aurelius_press_moderator_user) }
+  let(:admin)     { create(:aurelius_press_admin_user) }
+  let(:superuser) { create(:aurelius_press_superuser_user) }
+  let(:author)    { create(:aurelius_press_catalogue_author) }
+
+  permissions :index?, :show? do
+    it { is_expected.to permit(guest, author) }
+    it { is_expected.to permit(reader, author) }
+    it { is_expected.to permit(user, author) }
+    it { is_expected.to permit(moderator, author) }
+    it { is_expected.to permit(admin, author) }
+    it { is_expected.to permit(superuser, author) }
+  end
+
+  permissions :create?, :update?, :destroy? do
+    it { is_expected.not_to permit(guest, author) }
+    it { is_expected.not_to permit(reader, author) }
+    it { is_expected.not_to permit(user, author) }
+    it { is_expected.not_to permit(moderator, author) }
+    it { is_expected.to     permit(admin, author) }
+    it { is_expected.to     permit(superuser, author) }
+  end
+end

--- a/spec/policies/aurelius_press/catalogue/quote_policy_spec.rb
+++ b/spec/policies/aurelius_press/catalogue/quote_policy_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Catalogue::QuotePolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)     { nil }
+  let(:reader)    { create(:aurelius_press_reader_user) }
+  let(:user)      { create(:aurelius_press_user) }
+  let(:moderator) { create(:aurelius_press_moderator_user) }
+  let(:admin)     { create(:aurelius_press_admin_user) }
+  let(:superuser) { create(:aurelius_press_superuser_user) }
+  let(:source)    { create(:aurelius_press_catalogue_source) }
+  let(:quote)     { create(:aurelius_press_catalogue_quote, source: source) }
+
+  permissions :index?, :show? do
+    it { is_expected.to permit(guest, quote) }
+    it { is_expected.to permit(reader, quote) }
+    it { is_expected.to permit(user, quote) }
+    it { is_expected.to permit(moderator, quote) }
+    it { is_expected.to permit(admin, quote) }
+    it { is_expected.to permit(superuser, quote) }
+  end
+
+  permissions :create?, :update?, :destroy? do
+    it { is_expected.not_to permit(guest, quote) }
+    it { is_expected.not_to permit(reader, quote) }
+    it { is_expected.not_to permit(user, quote) }
+    it { is_expected.not_to permit(moderator, quote) }
+    it { is_expected.to     permit(admin, quote) }
+    it { is_expected.to     permit(superuser, quote) }
+  end
+end

--- a/spec/policies/aurelius_press/catalogue/source_policy_spec.rb
+++ b/spec/policies/aurelius_press/catalogue/source_policy_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Catalogue::SourcePolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)     { nil }
+  let(:reader)    { create(:aurelius_press_reader_user) }
+  let(:user)      { create(:aurelius_press_user) }
+  let(:moderator) { create(:aurelius_press_moderator_user) }
+  let(:admin)     { create(:aurelius_press_admin_user) }
+  let(:superuser) { create(:aurelius_press_superuser_user) }
+  let(:source)    { create(:aurelius_press_catalogue_source) }
+
+  permissions :index?, :show? do
+    it { is_expected.to permit(guest, source) }
+    it { is_expected.to permit(reader, source) }
+    it { is_expected.to permit(user, source) }
+    it { is_expected.to permit(moderator, source) }
+    it { is_expected.to permit(admin, source) }
+    it { is_expected.to permit(superuser, source) }
+  end
+
+  permissions :create?, :update?, :destroy? do
+    it { is_expected.not_to permit(guest, source) }
+    it { is_expected.not_to permit(reader, source) }
+    it { is_expected.not_to permit(user, source) }
+    it { is_expected.not_to permit(moderator, source) }
+    it { is_expected.to     permit(admin, source) }
+    it { is_expected.to     permit(superuser, source) }
+  end
+end

--- a/spec/policies/aurelius_press/community/group_membership_policy_spec.rb
+++ b/spec/policies/aurelius_press/community/group_membership_policy_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Community::GroupMembershipPolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)      { nil }
+  let(:reader)     { create(:aurelius_press_reader_user) }
+  let(:creator)    { create(:aurelius_press_user) }
+  let(:member)     { create(:aurelius_press_user) }
+  let(:non_member) { create(:aurelius_press_user) }
+  let(:moderator)  { create(:aurelius_press_moderator_user) }
+  let(:admin)      { create(:aurelius_press_admin_user) }
+  let(:superuser)  { create(:aurelius_press_superuser_user) }
+  let(:group)      { create(:aurelius_press_community_group, creator: creator) }
+  let(:membership) do
+    create(:aurelius_press_community_group_membership, group: group, user: member, status: :active)
+  end
+
+  permissions :create? do
+    it { is_expected.not_to permit(guest, membership) }
+    it { is_expected.not_to permit(reader, membership) }
+    it { is_expected.to     permit(non_member, membership) }
+    it { is_expected.to     permit(member, membership) }
+    it { is_expected.to     permit(moderator, membership) }
+    it { is_expected.to     permit(admin, membership) }
+    it { is_expected.to     permit(superuser, membership) }
+  end
+
+  permissions :destroy? do
+    it { is_expected.not_to permit(guest, membership) }
+    it { is_expected.not_to permit(reader, membership) }
+    it { is_expected.not_to permit(non_member, membership) }
+    it { is_expected.to     permit(member, membership) }
+    it { is_expected.to     permit(moderator, membership) }
+    it { is_expected.to     permit(admin, membership) }
+    it { is_expected.to     permit(superuser, membership) }
+  end
+end

--- a/spec/policies/aurelius_press/community/group_policy_spec.rb
+++ b/spec/policies/aurelius_press/community/group_policy_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Community::GroupPolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)      { nil }
+  let(:reader)     { create(:aurelius_press_reader_user) }
+  let(:creator)    { create(:aurelius_press_user) }
+  let(:non_member) { create(:aurelius_press_user) }
+  let(:moderator)  { create(:aurelius_press_moderator_user) }
+  let(:admin)      { create(:aurelius_press_admin_user) }
+  let(:superuser)  { create(:aurelius_press_superuser_user) }
+  let(:public_group) do
+    create(:aurelius_press_community_group, creator: creator, privacy_setting: :public_group)
+  end
+  let(:private_group) do
+    create(:aurelius_press_community_group, creator: creator, privacy_setting: :private_group)
+  end
+
+  permissions :index?, :create? do
+    it { is_expected.not_to permit(guest, public_group) }
+    it { is_expected.not_to permit(reader, public_group) }
+    it { is_expected.to     permit(non_member, public_group) }
+    it { is_expected.to     permit(creator, public_group) }
+    it { is_expected.to     permit(moderator, public_group) }
+    it { is_expected.to     permit(admin, public_group) }
+    it { is_expected.to     permit(superuser, public_group) }
+  end
+
+  permissions :show? do
+    context "on a public group" do
+      it { is_expected.not_to permit(guest, public_group) }
+      it { is_expected.not_to permit(reader, public_group) }
+      it { is_expected.to     permit(non_member, public_group) }
+      it { is_expected.to     permit(creator, public_group) }
+      it { is_expected.to     permit(moderator, public_group) }
+      it { is_expected.to     permit(admin, public_group) }
+      it { is_expected.to     permit(superuser, public_group) }
+    end
+
+    context "on a private group (non-member)" do
+      it { is_expected.not_to permit(non_member, private_group) }
+      it { is_expected.to     permit(creator, private_group) }
+      it { is_expected.to     permit(moderator, private_group) }
+    end
+  end
+
+  permissions :update?, :destroy? do
+    it { is_expected.not_to permit(guest, public_group) }
+    it { is_expected.not_to permit(reader, public_group) }
+    it { is_expected.not_to permit(non_member, public_group) }
+    it { is_expected.to     permit(creator, public_group) }
+    it { is_expected.to     permit(moderator, public_group) }
+    it { is_expected.to     permit(admin, public_group) }
+    it { is_expected.to     permit(superuser, public_group) }
+  end
+end

--- a/spec/policies/aurelius_press/community/like_policy_spec.rb
+++ b/spec/policies/aurelius_press/community/like_policy_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Community::LikePolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)      { nil }
+  let(:reader)     { create(:aurelius_press_reader_user) }
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:moderator)  { create(:aurelius_press_moderator_user) }
+  let(:admin)      { create(:aurelius_press_admin_user) }
+  let(:superuser)  { create(:aurelius_press_superuser_user) }
+  let(:likeable)   { create(:aurelius_press_document_blog_post, :visible_to_www) }
+  let(:like)       { create(:aurelius_press_community_like, user: owner, likeable: likeable) }
+
+  permissions :create? do
+    it { is_expected.not_to permit(guest, like) }
+    it { is_expected.not_to permit(reader, like) }
+    it { is_expected.to     permit(other_user, like) }
+    it { is_expected.to     permit(owner, like) }
+    it { is_expected.to     permit(moderator, like) }
+    it { is_expected.to     permit(admin, like) }
+    it { is_expected.to     permit(superuser, like) }
+  end
+
+  permissions :update?, :destroy? do
+    it { is_expected.not_to permit(guest, like) }
+    it { is_expected.not_to permit(reader, like) }
+    it { is_expected.not_to permit(other_user, like) }
+    it { is_expected.to     permit(owner, like) }
+    it { is_expected.to     permit(moderator, like) }
+    it { is_expected.to     permit(admin, like) }
+    it { is_expected.to     permit(superuser, like) }
+  end
+end

--- a/spec/policies/aurelius_press/document/content_block_policy_spec.rb
+++ b/spec/policies/aurelius_press/document/content_block_policy_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Document::ContentBlockPolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)      { nil }
+  let(:reader)     { create(:aurelius_press_reader_user) }
+  let(:doc_owner)  { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:moderator)  { create(:aurelius_press_moderator_user) }
+  let(:admin)      { create(:aurelius_press_admin_user) }
+  let(:superuser)  { create(:aurelius_press_superuser_user) }
+  let(:document)   { create(:aurelius_press_document_blog_post, :visible_to_www, user: doc_owner) }
+  let(:content_block) do
+    create(:aurelius_press_content_block_content_block, :as_rich_text_block, document: document)
+  end
+
+  permissions :index?, :show? do
+    it { is_expected.to permit(guest, content_block) }
+    it { is_expected.to permit(reader, content_block) }
+    it { is_expected.to permit(other_user, content_block) }
+    it { is_expected.to permit(doc_owner, content_block) }
+    it { is_expected.to permit(moderator, content_block) }
+    it { is_expected.to permit(admin, content_block) }
+    it { is_expected.to permit(superuser, content_block) }
+  end
+
+  permissions :create?, :update?, :destroy? do
+    it { is_expected.not_to permit(guest, content_block) }
+    it { is_expected.not_to permit(reader, content_block) }
+    it { is_expected.not_to permit(other_user, content_block) }
+    it { is_expected.to     permit(doc_owner, content_block) }
+    it { is_expected.to     permit(moderator, content_block) }
+    it { is_expected.to     permit(admin, content_block) }
+    it { is_expected.to     permit(superuser, content_block) }
+  end
+end

--- a/spec/policies/aurelius_press/fragment/comment_policy_spec.rb
+++ b/spec/policies/aurelius_press/fragment/comment_policy_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Fragment::CommentPolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)      { nil }
+  let(:reader)     { create(:aurelius_press_reader_user) }
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:moderator)  { create(:aurelius_press_moderator_user) }
+  let(:admin)      { create(:aurelius_press_admin_user) }
+  let(:superuser)  { create(:aurelius_press_superuser_user) }
+  let(:commentable) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+  let(:comment)     { create(:aurelius_press_fragment_comment, user: owner, commentable: commentable) }
+
+  permissions :index?, :show? do
+    it { is_expected.not_to permit(guest, comment) }
+    it { is_expected.to     permit(reader, comment) }
+    it { is_expected.to     permit(other_user, comment) }
+    it { is_expected.to     permit(owner, comment) }
+    it { is_expected.to     permit(moderator, comment) }
+    it { is_expected.to     permit(admin, comment) }
+    it { is_expected.to     permit(superuser, comment) }
+  end
+
+  permissions :create? do
+    it { is_expected.not_to permit(guest, comment) }
+    it { is_expected.not_to permit(reader, comment) }
+    it { is_expected.to     permit(other_user, comment) }
+    it { is_expected.to     permit(owner, comment) }
+    it { is_expected.to     permit(moderator, comment) }
+    it { is_expected.to     permit(admin, comment) }
+    it { is_expected.to     permit(superuser, comment) }
+  end
+
+  permissions :update?, :destroy? do
+    it { is_expected.not_to permit(guest, comment) }
+    it { is_expected.not_to permit(reader, comment) }
+    it { is_expected.not_to permit(other_user, comment) }
+    it { is_expected.to     permit(owner, comment) }
+    it { is_expected.to     permit(moderator, comment) }
+    it { is_expected.to     permit(admin, comment) }
+    it { is_expected.to     permit(superuser, comment) }
+  end
+
+  describe "Scope" do
+    subject(:scope) { described_class::Scope.new(actor, AureliusPress::Fragment::Comment).resolve }
+
+    let!(:comment_on_public_doc) do
+      create(:aurelius_press_fragment_comment,
+             user: owner,
+             commentable: create(:aurelius_press_document_blog_post, :visible_to_www))
+    end
+    let!(:comment_on_private_doc) do
+      create(:aurelius_press_fragment_comment,
+             user: owner,
+             commentable: create(:aurelius_press_document_blog_post))
+    end
+
+    context "when actor is a superuser" do
+      let(:actor) { superuser }
+
+      it "returns all comments" do
+        expect(scope).to include(comment_on_public_doc, comment_on_private_doc)
+      end
+    end
+
+    context "when actor is a regular user" do
+      let(:actor) { other_user }
+
+      it "returns comments on documents accessible to the user" do
+        expect(scope).to include(comment_on_public_doc)
+      end
+    end
+  end
+end

--- a/spec/policies/aurelius_press/fragment/note_policy_spec.rb
+++ b/spec/policies/aurelius_press/fragment/note_policy_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Fragment::NotePolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)      { nil }
+  let(:reader)     { create(:aurelius_press_reader_user) }
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:moderator)  { create(:aurelius_press_moderator_user) }
+  let(:admin)      { create(:aurelius_press_admin_user) }
+  let(:superuser)  { create(:aurelius_press_superuser_user) }
+  let(:notable)    { create(:aurelius_press_document_blog_post, :visible_to_www) }
+  let(:note)       { create(:aurelius_press_fragment_note, user: owner, notable: notable) }
+
+  permissions :index?, :create? do
+    it { is_expected.not_to permit(guest, note) }
+    it { is_expected.not_to permit(reader, note) }
+    it { is_expected.to     permit(other_user, note) }
+    it { is_expected.to     permit(owner, note) }
+    it { is_expected.to     permit(moderator, note) }
+    it { is_expected.to     permit(admin, note) }
+    it { is_expected.to     permit(superuser, note) }
+  end
+
+  permissions :show?, :update?, :destroy? do
+    it { is_expected.not_to permit(guest, note) }
+    it { is_expected.not_to permit(reader, note) }
+    it { is_expected.not_to permit(other_user, note) }
+    it { is_expected.to     permit(owner, note) }
+    it { is_expected.to     permit(moderator, note) }
+    it { is_expected.to     permit(admin, note) }
+    it { is_expected.to     permit(superuser, note) }
+  end
+
+  describe "Scope" do
+    subject(:scope) { described_class::Scope.new(actor, AureliusPress::Fragment::Note).resolve }
+
+    let!(:my_note)    { create(:aurelius_press_fragment_note, user: owner, notable: notable) }
+    let!(:other_note) { create(:aurelius_press_fragment_note, user: other_user, notable: notable) }
+
+    context "when actor is the owner" do
+      let(:actor) { owner }
+
+      it "returns only own notes" do
+        expect(scope).to include(my_note)
+        expect(scope).not_to include(other_note)
+      end
+    end
+
+    context "when actor is a power user" do
+      let(:actor) { superuser }
+
+      it "returns all notes" do
+        expect(scope).to include(my_note, other_note)
+      end
+    end
+  end
+end

--- a/spec/policies/aurelius_press/taxonomy/category_policy_spec.rb
+++ b/spec/policies/aurelius_press/taxonomy/category_policy_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Taxonomy::CategoryPolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)     { nil }
+  let(:reader)    { create(:aurelius_press_reader_user) }
+  let(:user)      { create(:aurelius_press_user) }
+  let(:moderator) { create(:aurelius_press_moderator_user) }
+  let(:admin)     { create(:aurelius_press_admin_user) }
+  let(:superuser) { create(:aurelius_press_superuser_user) }
+  let(:category)  { create(:aurelius_press_taxonomy_category) }
+
+  permissions :index?, :show? do
+    it { is_expected.to permit(guest, category) }
+    it { is_expected.to permit(reader, category) }
+    it { is_expected.to permit(user, category) }
+    it { is_expected.to permit(moderator, category) }
+    it { is_expected.to permit(admin, category) }
+    it { is_expected.to permit(superuser, category) }
+  end
+
+  permissions :create?, :update?, :destroy? do
+    it { is_expected.not_to permit(guest, category) }
+    it { is_expected.not_to permit(reader, category) }
+    it { is_expected.not_to permit(user, category) }
+    it { is_expected.not_to permit(moderator, category) }
+    it { is_expected.to     permit(admin, category) }
+    it { is_expected.to     permit(superuser, category) }
+  end
+end

--- a/spec/policies/aurelius_press/taxonomy/tag_policy_spec.rb
+++ b/spec/policies/aurelius_press/taxonomy/tag_policy_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe AureliusPress::Taxonomy::TagPolicy, type: :policy do
+  subject { described_class }
+
+  let(:guest)     { nil }
+  let(:reader)    { create(:aurelius_press_reader_user) }
+  let(:user)      { create(:aurelius_press_user) }
+  let(:moderator) { create(:aurelius_press_moderator_user) }
+  let(:admin)     { create(:aurelius_press_admin_user) }
+  let(:superuser) { create(:aurelius_press_superuser_user) }
+  let(:tag)       { create(:aurelius_press_taxonomy_tag) }
+
+  permissions :index?, :show? do
+    it { is_expected.to permit(guest, tag) }
+    it { is_expected.to permit(reader, tag) }
+    it { is_expected.to permit(user, tag) }
+    it { is_expected.to permit(moderator, tag) }
+    it { is_expected.to permit(admin, tag) }
+    it { is_expected.to permit(superuser, tag) }
+  end
+
+  permissions :create?, :update?, :destroy? do
+    it { is_expected.not_to permit(guest, tag) }
+    it { is_expected.not_to permit(reader, tag) }
+    it { is_expected.not_to permit(user, tag) }
+    it { is_expected.not_to permit(moderator, tag) }
+    it { is_expected.to     permit(admin, tag) }
+    it { is_expected.to     permit(superuser, tag) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ require "action_dispatch/testing/test_process"
 require "database_cleaner/active_record"
 
 require "support/action_text_helper"
+require "pundit/rspec"
 
 # Require the top-level module first to stop rspec from spazzing-out!
 require_relative "../app/modules/aurelius_press"

--- a/spec/requests/aurelius_press/community/likes_spec.rb
+++ b/spec/requests/aurelius_press/community/likes_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Community::Likes", type: :request do
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:blog_post)  { create(:aurelius_press_document_blog_post, :visible_to_www) }
+  let!(:like)      { create(:aurelius_press_community_like, :like_state, user: owner, likeable: blog_post) }
+
+  # ── POST /aurelius-press/community/likes ──────────────────────────────────
+
+  describe "POST /aurelius-press/community/likes" do
+    let(:valid_params) do
+      { like: { likeable_gid: blog_post.to_global_id.to_s, state: "like" } }
+    end
+
+    context "when authenticated as a user" do
+      before { sign_in other_user }
+
+      it "creates a like record" do
+        expect {
+          post aurelius_press_community_likes_path, params: valid_params
+        }.to change(AureliusPress::Community::Like, :count).by(1)
+      end
+
+      it "responds with success or redirect" do
+        post aurelius_press_community_likes_path, params: valid_params
+        expect(response).to have_http_status(:success).or have_http_status(:redirect)
+      end
+
+      it "toggles to no_reaction when posting the same state again" do
+        post aurelius_press_community_likes_path, params: valid_params
+        expect(AureliusPress::Community::Like.last.state).to eq("like")
+
+        post aurelius_press_community_likes_path, params: valid_params
+        expect(AureliusPress::Community::Like.last.state).to eq("no_reaction")
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_community_likes_path, params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── DELETE /aurelius-press/community/likes/:id ────────────────────────────
+
+  describe "DELETE /aurelius-press/community/likes/:id" do
+    context "when authenticated as the like owner" do
+      before { sign_in owner }
+
+      it "destroys the like" do
+        expect {
+          delete aurelius_press_community_like_path(like)
+        }.to change(AureliusPress::Community::Like, :count).by(-1)
+      end
+
+      it "responds with success or redirect" do
+        delete aurelius_press_community_like_path(like)
+        expect(response).to have_http_status(:success).or have_http_status(:redirect)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the like" do
+        expect {
+          delete aurelius_press_community_like_path(like)
+        }.not_to change(AureliusPress::Community::Like, :count)
+      end
+
+      it "returns forbidden or redirects" do
+        delete aurelius_press_community_like_path(like)
+        expect(response).to have_http_status(:forbidden).or have_http_status(:redirect)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_community_like_path(like)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add 11 Pundit policies covering all major resource types (fragments, community, catalogue, document, taxonomy)
- Move `LikesController` into `AureliusPress::Community` namespace; adopt GlobalID + `state` toggle pattern matching the engagement bar
- Add policy specs (11 files, 160+ examples) and request specs for likes — 174 examples total, 0 failures
- Add `design/backlog.md`, `design/sprint_1.md`, `design/testing_strategy.md`
- Update routes: `namespace :community` with reactions + likes; `namespace :taxonomy` for public tag/category pages

## Policies shipped

| Policy | Key rules |
|---|---|
| `Fragment::CommentPolicy` | Authenticated read; owner or power-user write; scope filters by accessible docs |
| `Fragment::NotePolicy` | Private by default; owner-only read/write; power-user override |
| `Community::LikePolicy` | `user+` create; owner or power-user destroy |
| `Community::GroupPolicy` | Public groups visible to all; private groups to creator + members |
| `Community::GroupMembershipPolicy` | `user+` join; member or power-user leave |
| `Catalogue::AuthorPolicy` | Public read; admin+ write |
| `Catalogue::SourcePolicy` | Public read; admin+ write |
| `Catalogue::QuotePolicy` | Public read; admin+ write |
| `Document::ContentBlockPolicy` | Public read; document owner or power-user write |
| `Taxonomy::TagPolicy` | Public read; admin+ write |
| `Taxonomy::CategoryPolicy` | Public read; admin+ write |

## Test plan

- [x] `bundle exec rspec spec/policies/ spec/requests/aurelius_press/community/likes_spec.rb` — 174 examples, 0 failures
- [x] Conflicts from rebase onto updated `master` resolved (routes, comment policy, backlog, likes controller)
- [ ] Full suite run before merge recommended