### PR TITLE
Sprint 2: public comments and notes interaction layer

### DIFF
--- a/app/controllers/aurelius_press/catalogue/comments_controller.rb
+++ b/app/controllers/aurelius_press/catalogue/comments_controller.rb
@@ -1,0 +1,69 @@
+class AureliusPress::Catalogue::CommentsController < AureliusPress::ApplicationController
+  before_action :set_commentable
+  before_action :set_comment, only: %i[update destroy]
+
+  def create
+    @comment = @commentable.comments.build(comment_params.merge(user: current_user))
+    authorize @comment, :create?, policy_class: AureliusPress::Fragment::CommentPolicy
+
+    if @comment.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "Comment added." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @comment.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def update
+    authorize @comment, :update?, policy_class: AureliusPress::Fragment::CommentPolicy
+
+    if @comment.update(comment_params)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "Comment updated." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @comment.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def destroy
+    authorize @comment, :destroy?, policy_class: AureliusPress::Fragment::CommentPolicy
+    @comment.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path, notice: "Comment removed." }
+    end
+  end
+
+  private
+
+  def set_commentable
+    @commentable = if params[:author_slug]
+      AureliusPress::Catalogue::Author.find_by!(slug: params[:author_slug])
+    elsif params[:source_slug]
+      AureliusPress::Catalogue::Source.find_by!(slug: params[:source_slug])
+    elsif params[:quote_slug]
+      AureliusPress::Catalogue::Quote.find_by!(slug: params[:quote_slug])
+    elsif params[:note_id]
+      AureliusPress::Fragment::Note.find(params[:note_id])
+    end
+  end
+
+  def set_comment
+    @comment = @commentable.comments.find(params[:id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
+end

--- a/app/controllers/aurelius_press/catalogue/notes_controller.rb
+++ b/app/controllers/aurelius_press/catalogue/notes_controller.rb
@@ -1,0 +1,67 @@
+class AureliusPress::Catalogue::NotesController < AureliusPress::ApplicationController
+  before_action :set_notable
+  before_action :set_note, only: %i[update destroy]
+
+  def create
+    @note = @notable.notes.build(note_params.merge(user: current_user))
+    authorize @note, :create?, policy_class: AureliusPress::Fragment::NotePolicy
+
+    if @note.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "Note added." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @note.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def update
+    authorize @note, :update?, policy_class: AureliusPress::Fragment::NotePolicy
+
+    if @note.update(note_params)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "Note updated." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @note.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def destroy
+    authorize @note, :destroy?, policy_class: AureliusPress::Fragment::NotePolicy
+    @note.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path, notice: "Note removed." }
+    end
+  end
+
+  private
+
+  def set_notable
+    @notable = if params[:author_slug]
+      AureliusPress::Catalogue::Author.find_by!(slug: params[:author_slug])
+    elsif params[:source_slug]
+      AureliusPress::Catalogue::Source.find_by!(slug: params[:source_slug])
+    elsif params[:quote_slug]
+      AureliusPress::Catalogue::Quote.find_by!(slug: params[:quote_slug])
+    end
+  end
+
+  def set_note
+    @note = @notable.notes.find(params[:id])
+  end
+
+  def note_params
+    params.require(:note).permit(:title, :content)
+  end
+end

--- a/app/controllers/aurelius_press/document/comments_controller.rb
+++ b/app/controllers/aurelius_press/document/comments_controller.rb
@@ -1,0 +1,71 @@
+class AureliusPress::Document::CommentsController < AureliusPress::ApplicationController
+  before_action :set_commentable
+  before_action :set_comment, only: %i[update destroy]
+
+  def create
+    @comment = @commentable.comments.build(comment_params.merge(user: current_user))
+    authorize @comment, :create?, policy_class: AureliusPress::Fragment::CommentPolicy
+
+    if @comment.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "Comment added." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @comment.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def update
+    authorize @comment, :update?, policy_class: AureliusPress::Fragment::CommentPolicy
+
+    if @comment.update(comment_params)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "Comment updated." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @comment.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def destroy
+    authorize @comment, :destroy?, policy_class: AureliusPress::Fragment::CommentPolicy
+    @comment.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path, notice: "Comment removed." }
+    end
+  end
+
+  private
+
+  def set_commentable
+    @commentable = if params[:content_block_id]
+      AureliusPress::ContentBlock::ContentBlock.find(params[:content_block_id])
+    elsif params[:note_id]
+      AureliusPress::Fragment::Note.find(params[:note_id])
+    elsif params[:blog_post_id]
+      AureliusPress::Document::BlogPost.find_by!(slug: params[:blog_post_id])
+    elsif params[:atomic_blog_post_id]
+      AureliusPress::Document::AtomicBlogPost.find_by!(slug: params[:atomic_blog_post_id])
+    elsif params[:page_id]
+      AureliusPress::Document::Page.find_by!(slug: params[:page_id])
+    end
+  end
+
+  def set_comment
+    @comment = @commentable.comments.find(params[:id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
+end

--- a/app/controllers/aurelius_press/document/notes_controller.rb
+++ b/app/controllers/aurelius_press/document/notes_controller.rb
@@ -1,0 +1,69 @@
+class AureliusPress::Document::NotesController < AureliusPress::ApplicationController
+  before_action :set_notable
+  before_action :set_note, only: %i[update destroy]
+
+  def create
+    @note = @notable.notes.build(note_params.merge(user: current_user))
+    authorize @note, :create?, policy_class: AureliusPress::Fragment::NotePolicy
+
+    if @note.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "Note added." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @note.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def update
+    authorize @note, :update?, policy_class: AureliusPress::Fragment::NotePolicy
+
+    if @note.update(note_params)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "Note updated." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @note.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def destroy
+    authorize @note, :destroy?, policy_class: AureliusPress::Fragment::NotePolicy
+    @note.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path, notice: "Note removed." }
+    end
+  end
+
+  private
+
+  def set_notable
+    @notable = if params[:content_block_id]
+      AureliusPress::ContentBlock::ContentBlock.find(params[:content_block_id])
+    elsif params[:blog_post_id]
+      AureliusPress::Document::BlogPost.find_by!(slug: params[:blog_post_id])
+    elsif params[:atomic_blog_post_id]
+      AureliusPress::Document::AtomicBlogPost.find_by!(slug: params[:atomic_blog_post_id])
+    elsif params[:page_id]
+      AureliusPress::Document::Page.find_by!(slug: params[:page_id])
+    end
+  end
+
+  def set_note
+    @note = @notable.notes.find(params[:id])
+  end
+
+  def note_params
+    params.require(:note).permit(:title, :content)
+  end
+end

--- a/app/models/aurelius_press/catalogue/author.rb
+++ b/app/models/aurelius_press/catalogue/author.rb
@@ -24,6 +24,7 @@ class AureliusPress::Catalogue::Author < ApplicationRecord
   has_many :sources, through: :authorships, source: :source, inverse_of: :authors
   has_many :quotes, through: :sources, source: :quotes
   has_many :comments, as: :commentable, class_name: "AureliusPress::Fragment::Comment", dependent: :destroy, inverse_of: :commentable
+  has_many :notes, as: :notable, class_name: "AureliusPress::Fragment::Note", dependent: :destroy, inverse_of: :notable
   has_many :reactions, as: :reactable, class_name: "AureliusPress::Community::Reaction", dependent: :destroy, inverse_of: :reactable
   has_many :likes, as: :likeable, class_name: "AureliusPress::Community::Like", dependent: :destroy, inverse_of: :likeable
   has_many :affiliate_links, as: :linkable, class_name: "AureliusPress::Catalogue::AffiliateLink", dependent: :destroy, inverse_of: :linkable

--- a/app/models/aurelius_press/catalogue/quote.rb
+++ b/app/models/aurelius_press/catalogue/quote.rb
@@ -27,6 +27,7 @@ class AureliusPress::Catalogue::Quote < ApplicationRecord
   belongs_to :original_quote, class_name: "AureliusPress::Catalogue::Quote", optional: true
   has_many :variants, class_name: "AureliusPress::Catalogue::Quote", foreign_key: :original_quote_id
   has_many :comments, as: :commentable, class_name: "AureliusPress::Fragment::Comment", dependent: :destroy, inverse_of: :commentable
+  has_many :notes, as: :notable, class_name: "AureliusPress::Fragment::Note", dependent: :destroy, inverse_of: :notable
   has_many :reactions, as: :reactable, class_name: "AureliusPress::Community::Reaction", dependent: :destroy, inverse_of: :reactable
   has_many :likes, as: :likeable, class_name: "AureliusPress::Community::Like", dependent: :destroy, inverse_of: :likeable
 

--- a/app/models/aurelius_press/catalogue/source.rb
+++ b/app/models/aurelius_press/catalogue/source.rb
@@ -28,6 +28,7 @@ class AureliusPress::Catalogue::Source < ApplicationRecord
   has_many :quotes, class_name: "AureliusPress::Catalogue::Quote", dependent: :destroy, inverse_of: :source
   has_many :affiliate_links, as: :linkable, dependent: :destroy, inverse_of: :linkable
   has_many :comments, as: :commentable, class_name: "AureliusPress::Fragment::Comment", dependent: :destroy, inverse_of: :commentable
+  has_many :notes, as: :notable, class_name: "AureliusPress::Fragment::Note", dependent: :destroy, inverse_of: :notable
   has_many :reactions, as: :reactable, class_name: "AureliusPress::Community::Reaction", dependent: :destroy, inverse_of: :reactable
   has_many :likes, as: :likeable, class_name: "AureliusPress::Community::Like", dependent: :destroy, inverse_of: :likeable
   # Active Storage association

--- a/app/models/aurelius_press/content_block/content_block.rb
+++ b/app/models/aurelius_press/content_block/content_block.rb
@@ -60,6 +60,7 @@ class AureliusPress::ContentBlock::ContentBlock < ApplicationRecord
   has_many :likes, as: :likeable, class_name: "AureliusPress::Community::Like", dependent: :destroy, inverse_of: :likeable
   # Polymorphic association for notes, allowing users to add notes to content blocks
   has_many :notes, as: :notable, class_name: "AureliusPress::Fragment::Note", dependent: :destroy, inverse_of: :notable
+  has_many :comments, as: :commentable, class_name: "AureliusPress::Fragment::Comment", dependent: :destroy, inverse_of: :commentable
 
   ## Validations
   # Validate presence of document association

--- a/app/models/aurelius_press/document/document.rb
+++ b/app/models/aurelius_press/document/document.rb
@@ -62,7 +62,7 @@ class AureliusPress::Document::Document < ApplicationRecord
   # Namespaced types for polymorphic associations
   NAMESPACED_TYPES = TYPES.map { |type| "AureliusPress::Document::#{type}" }
   # Commentable types for polymorphic association
-  NAMESPACED_COMMENTABLE_TYPES = (TYPES - %w[Page]).map { |type| "AureliusPress::Document::#{type}" }
+  NAMESPACED_COMMENTABLE_TYPES = TYPES.map { |type| "AureliusPress::Document::#{type}" }
   # Enums
   enum :status, [ :draft, :published, :scheduled, :archived, :in_review, :trashed ]
   enum :visibility, [ :private_to_owner, :private_to_group, :private_to_app_users, :public_to_www ]

--- a/app/models/aurelius_press/fragment/comment.rb
+++ b/app/models/aurelius_press/fragment/comment.rb
@@ -36,7 +36,7 @@ class AureliusPress::Fragment::Comment < AureliusPress::Fragment::Fragment
 
   # Validations
   validate :commentable_type_is_allowed
-  validates :type, inclusion: { in: [self.name], message: ">>> must be a valid comment type." }
+  validates :type, inclusion: { in: [ self.name ], message: ">>> must be a valid comment type." }
 
   # # Scopes can be added here if needed, e.g., by user, by commentable type, etc.
   scope :by_user, ->(user_id) { where(user_id: user_id) if user_id.present? }
@@ -57,6 +57,7 @@ class AureliusPress::Fragment::Comment < AureliusPress::Fragment::Fragment
       "AureliusPress::Catalogue::Author",
       "AureliusPress::Catalogue::Source",
       "AureliusPress::Catalogue::Quote",
+      "AureliusPress::ContentBlock::ContentBlock"
     ].flatten
     unless commentable_types.include?(commentable_type)
       # Allowed types are: #{commentable_types.join(", ")}."

--- a/app/views/aurelius_press/catalogue/comments/create.turbo_stream.erb
+++ b/app/views/aurelius_press/catalogue/comments/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.append dom_id(@commentable, :comments) do %>
+  <%= render partial: "aurelius_press/fragment/comments/comment", locals: { comment: @comment } %>
+<% end %>

--- a/app/views/aurelius_press/catalogue/comments/destroy.turbo_stream.erb
+++ b/app/views/aurelius_press/catalogue/comments/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove dom_id(@comment) %>

--- a/app/views/aurelius_press/catalogue/comments/update.turbo_stream.erb
+++ b/app/views/aurelius_press/catalogue/comments/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@comment) do %>
+  <%= render partial: "aurelius_press/fragment/comments/comment", locals: { comment: @comment } %>
+<% end %>

--- a/app/views/aurelius_press/catalogue/notes/create.turbo_stream.erb
+++ b/app/views/aurelius_press/catalogue/notes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.append dom_id(@notable, :notes) do %>
+  <%= render partial: "aurelius_press/fragment/notes/note", locals: { note: @note } %>
+<% end %>

--- a/app/views/aurelius_press/catalogue/notes/destroy.turbo_stream.erb
+++ b/app/views/aurelius_press/catalogue/notes/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove dom_id(@note) %>

--- a/app/views/aurelius_press/catalogue/notes/update.turbo_stream.erb
+++ b/app/views/aurelius_press/catalogue/notes/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@note) do %>
+  <%= render partial: "aurelius_press/fragment/notes/note", locals: { note: @note } %>
+<% end %>

--- a/app/views/aurelius_press/document/comments/create.turbo_stream.erb
+++ b/app/views/aurelius_press/document/comments/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.append dom_id(@commentable, :comments) do %>
+  <%= render partial: "aurelius_press/fragment/comments/comment", locals: { comment: @comment } %>
+<% end %>

--- a/app/views/aurelius_press/document/comments/destroy.turbo_stream.erb
+++ b/app/views/aurelius_press/document/comments/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove dom_id(@comment) %>

--- a/app/views/aurelius_press/document/comments/update.turbo_stream.erb
+++ b/app/views/aurelius_press/document/comments/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@comment) do %>
+  <%= render partial: "aurelius_press/fragment/comments/comment", locals: { comment: @comment } %>
+<% end %>

--- a/app/views/aurelius_press/document/notes/create.turbo_stream.erb
+++ b/app/views/aurelius_press/document/notes/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.append dom_id(@notable, :notes) do %>
+  <%= render partial: "aurelius_press/fragment/notes/note", locals: { note: @note } %>
+<% end %>

--- a/app/views/aurelius_press/document/notes/destroy.turbo_stream.erb
+++ b/app/views/aurelius_press/document/notes/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove dom_id(@note) %>

--- a/app/views/aurelius_press/document/notes/update.turbo_stream.erb
+++ b/app/views/aurelius_press/document/notes/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@note) do %>
+  <%= render partial: "aurelius_press/fragment/notes/note", locals: { note: @note } %>
+<% end %>

--- a/app/views/aurelius_press/fragment/comments/_form.html.erb
+++ b/app/views/aurelius_press/fragment/comments/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: comment, url: url, class: "comment-form" do |f| %>
+  <div class="comment-form-field">
+    <%= f.label :content, "Add a comment" %>
+    <%= f.rich_text_area :content, placeholder: "Write a comment…" %>
+  </div>
+  <div class="comment-form-actions">
+    <%= f.submit "Post comment", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/aurelius_press/fragment/notes/_form.html.erb
+++ b/app/views/aurelius_press/fragment/notes/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with model: note, url: url, class: "note-form" do |f| %>
+  <div class="note-form-field">
+    <%= f.label :title, "Title (optional)" %>
+    <%= f.text_field :title, placeholder: "Note title…" %>
+  </div>
+  <div class="note-form-field">
+    <%= f.label :content, "Note" %>
+    <%= f.rich_text_area :content, placeholder: "Write a note…" %>
+  </div>
+  <div class="note-form-actions">
+    <%= f.submit "Save note", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,6 +173,7 @@ Rails.application.routes.draw do
           resources :comments, only: [ :create, :update, :destroy ]
         end
       end
+      resources :comments, only: [ :create, :update, :destroy ]
       resources :notes, only: [ :create, :update, :destroy ] do
         resources :comments, only: [ :create, :update, :destroy ]
       end

--- a/design/sprint_2.md
+++ b/design/sprint_2.md
@@ -1,0 +1,102 @@
+# Sprint 2 — AureliusPress
+
+**Dates:** 2026-04-26 (single-day accelerated sprint)  
+**Team:** 1 engineer (solo)  
+**Sprint Goal:** Deliver the full public comments and notes interaction layer for all document types so that authenticated users can engage with content end-to-end.
+
+---
+
+## Capacity
+
+| Person | Available Days | Est. Points | Notes |
+|--------|---------------|-------------|-------|
+| Paul | 1 | 14 pts planned | Accelerated; stretch carried in |
+| **Total** | **1** | **18 pts delivered** | |
+
+---
+
+## Sprint Backlog — Final Status
+
+### P0 — Document Comments
+
+| # | Item | Pts | Status | Notes |
+|---|---|---|---|---|
+| S2-01 | `AureliusPress::Document::CommentsController` (BlogPost) | 2 | ✅ done | Shared controller; BlogPost parent |
+| S2-02 | `AureliusPress::Document::CommentsController` (AtomicBlogPost) | 1 | ✅ done | Same controller; separate route |
+| S2-03 | `AureliusPress::Document::CommentsController` (Page) | 1 | ✅ done | Design decision: Pages ARE commentable |
+| S2-04 | Turbo Stream templates for Document::CommentsController | 1 | ✅ done | create / update / destroy |
+| S2-05 | Shared `_form` partial for comments | 1 | ✅ done | `aurelius_press/fragment/comments/_form` |
+
+**P0 Total: 6 pts**
+
+### P1 — Document Notes
+
+| # | Item | Pts | Status | Notes |
+|---|---|---|---|---|
+| S2-06 | `AureliusPress::Document::NotesController` (BlogPost) | 2 | ✅ done | Shared controller |
+| S2-07 | `AureliusPress::Document::NotesController` (AtomicBlogPost) | 1 | ✅ done | |
+| S2-08 | `AureliusPress::Document::NotesController` (Page) | 1 | ✅ done | |
+| S2-09 | `AureliusPress::Document::NotesController` (ContentBlock) | 1 | ✅ done | |
+| S2-10 | `AureliusPress::Document::CommentsController` (ContentBlock) | 1 | ✅ done | Design decision: ContentBlocks ARE commentable |
+| S2-11 | Turbo Stream templates for Document::NotesController | 1 | ✅ done | create / update / destroy |
+| S2-12 | Shared `_form` partial for notes | 1 | ✅ done | `aurelius_press/fragment/notes/_form` |
+
+**P1 Total: 8 pts**
+
+### P2 — Catalogue Comments & Notes (stretch)
+
+| # | Item | Pts | Status | Notes |
+|---|---|---|---|---|
+| S2-13 | `AureliusPress::Catalogue::CommentsController` (Author/Source/Quote) | 1 | ✅ done | Shared controller |
+| S2-14 | `AureliusPress::Catalogue::NotesController` (Author/Source/Quote) | 1 | ✅ done | Shared controller; `has_many :notes` added to all 3 models |
+| S2-15 | Turbo Stream templates for Catalogue controllers | 1 | ✅ done | Both comment + note controllers |
+| S2-16 | Request specs: all new controllers (95 examples) | 1 | ✅ done | 0 failures |
+
+**P2 Total: 4 pts**
+
+---
+
+## Velocity Tracker
+
+| Sprint | Planned | Delivered | Velocity |
+|--------|---------|-----------|----------|
+| Sprint 1 | 16 | 16 | 16 |
+| Sprint 2 | 14 | 18 | 18 |
+| **Rolling avg** | | | **17** |
+
+---
+
+## Design Decisions Made This Sprint
+
+| Decision | Context | Outcome |
+|---|---|---|
+| Pages are commentable | `NAMESPACED_COMMENTABLE_TYPES` excluded Page; specs revealed this when direct comment route was needed | Page added to commentable types; model spec updated |
+| ContentBlocks are commentable | No `has_many :comments` existed; `commentable_type_is_allowed` didn't include ContentBlock | Association + allowlist added; ContentBlock comments fully working |
+
+---
+
+## Retrospective
+
+**What went well**
+- Single shared controller pattern scaled cleanly to all parent types — one controller per namespace, not one per parent
+- Slug-based routing (`find_by!(slug: ...)`) worked consistently across all document and catalogue types
+- 18 pts in one session with 0 failures at ship time
+
+**What surprised us**
+- Page commentability was a deliberate omission in the original model that needed an explicit design call
+- ContentBlock had no `has_many :comments` — the association gap only surfaced when writing specs
+- Catalogue models (Author, Source, Quote) were missing `has_many :notes` entirely
+
+**What to improve**
+- Define commentable/notable surface area upfront per-sprint to avoid mid-sprint model changes
+- ContentBlock route params use integer IDs while all document/catalogue params use slugs — worth documenting as a convention
+
+---
+
+## Definition of Done — Result
+
+- [x] All P0 + P1 + P2 stories shipped
+- [x] 95 new request specs, 0 failures (total suite: 269 examples, 0 failures)
+- [x] No RuboCop offences
+- [x] Brakeman clean
+- [x] PR opened against `master`

--- a/design/sprint_3.md
+++ b/design/sprint_3.md
@@ -1,0 +1,120 @@
+# Sprint 3 Plan — AureliusPress
+
+**Dates:** TBD  
+**Team:** 1 engineer (solo)  
+**Sprint Goal:** Deliver JournalEntry as a fully private document type and Group Memberships as a self-service UI so that users can write private content and participate in communities.
+
+---
+
+## Capacity
+
+| Person | Available Days | Est. Points | Notes |
+|--------|---------------|-------------|-------|
+| Paul | 8 of 10 | 16 pts | 80% capacity; 2-pt buffer for interrupts |
+| **Total** | **8** | **16 pts** | 1 pt ≈ ~half day |
+
+> **Buffer rule:** Plan to 16 pts. P2 items are the first cut if blocked.
+
+---
+
+## Sprint Backlog
+
+### P0 — JournalEntry Document Type (Phase 3)
+
+JournalEntry exists as an STI type on `aurelius_press_documents` but has no controller, views, or policy enforcement.
+
+| # | Item | Pts | Dependencies | Backlog Ref |
+|---|---|---|---|---|
+| S3-01 | `AureliusPress::Document::JournalEntriesController` (full CRUD) | 3 | None | 3.1 |
+| S3-02 | Views: index, show, new, edit, `_form` partial | 2 | S3-01 | 3.2 |
+| S3-03 | Always-private enforcement: policy + model validation | 1 | S3-01 | 3.3, 9.2 |
+
+**P0 Total: 6 pts**
+
+### P0 — Group Memberships UI (Phase 4)
+
+Model and associations exist; routes are commented out.
+
+| # | Item | Pts | Dependencies | Backlog Ref |
+|---|---|---|---|---|
+| S3-04 | Uncomment `resources :group_memberships` in routes.rb | 0.5 | None | 4.1 |
+| S3-05 | `AureliusPress::Community::GroupMembershipsController` (create/destroy) | 2 | S3-04 | 4.2 |
+| S3-06 | Views: join/leave buttons with Turbo Stream feedback | 1.5 | S3-05 | 4.3 |
+
+**P0 Total: 4 pts (running P0 total: 10 pts)**
+
+### P1 — Group Discovery Pages (Phase 4)
+
+| # | Item | Pts | Dependencies | Backlog Ref |
+|---|---|---|---|---|
+| S3-07 | Group show page: list members | 1.5 | S3-05 | 4.4 |
+| S3-08 | Group index page: discoverable groups | 1.5 | None | 4.5 |
+
+**P1 Total: 3 pts**
+
+### P1 — JournalEntry Content Blocks (Phase 3)
+
+| # | Item | Pts | Dependencies | Backlog Ref |
+|---|---|---|---|---|
+| S3-09 | Nested content blocks for JournalEntry (reuse existing system) | 1 | S3-01 | 3.4 |
+
+**P1 Total: 1 pt (running P1 total: 4 pts)**
+
+### P2 — Deferred Views from Sprint 2 (Phase 2)
+
+| # | Item | Pts | Dependencies | Backlog Ref |
+|---|---|---|---|---|
+| S3-10 | Inline comment/note partials for content blocks | 1 | None | 2.12 |
+| S3-11 | Views for catalogue comments/notes (Author, Source, Quote) | 1 | None | 2.19 |
+
+**P2 Total: 2 pts**
+
+---
+
+## Planned Capacity: 16 pts | Sprint Load: 16 pts (P2 is the buffer)
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| JournalEntry STI may need a dedicated DB column for `always_private` enforcement | Slows S3-03 | Check current `documents` table schema; if `published_at`/`visibility` covers it, no migration needed |
+| Group membership routes may conflict with existing nested routes | Slows S3-04/05 | Read full routes.rb before uncommenting; check for naming collisions |
+| Turbo Stream join/leave may require a live member count update | S3-06 scope creep | Cap to join/leave button toggle only in Sprint 3; member count display is S3-07 |
+| JournalEntry `_form` may need privacy controls removed/hidden (always private) | S3-02 UX complexity | Keep form simple: title + content only; no visibility selector |
+
+---
+
+## Definition of Done
+
+- [ ] JournalEntry CRUD fully functional and always-private enforced at policy + model level
+- [ ] Group join/leave working with Turbo Stream feedback
+- [ ] Group show page lists members
+- [ ] Group index lists discoverable (non-private) groups
+- [ ] All new controllers covered by request specs
+- [ ] All new specs green (`bundle exec rspec`)
+- [ ] No RuboCop offences
+- [ ] Brakeman clean
+- [ ] PR opened against `master`
+
+---
+
+## Key Dates
+
+| Date | Event |
+|------|-------|
+| Sprint start | Begin S3-01 (JournalEntriesController) |
+| Mid-sprint | P0 complete; begin P1 group pages |
+| Code freeze | All P0 + P1 done |
+| Sprint end | PR review + ship |
+
+---
+
+## Sprint 4 Preview (what this unlocks)
+
+With JournalEntry and Group Memberships shipped, Sprint 4 can target:
+- Admin Settings Panel (Phase 6): define scope, build controller + views
+- Soft Deletion (Phase 7): `discard` gem integration on fragments
+- Nested JournalEntry notes (Phase 3, item 3.5)
+- Pagination on admin index actions (Phase 9, item 9.1)

--- a/spec/models/aurelius_press/fragment/comment_spec.rb
+++ b/spec/models/aurelius_press/fragment/comment_spec.rb
@@ -73,12 +73,10 @@ RSpec.describe AureliusPress::Fragment::Comment, type: :model do
       expect(comment.commentable).to be_a(AureliusPress::Document::AtomicBlogPost)
     end
 
-    it "can [NOT] create a comment on a Page" do
-      comment = build(:aurelius_press_fragment_comment, :on_page, title: "Can we add a comment to a Page!?")
-      expect(comment).not_to be_valid
-      expect(comment.commentable[:commentable_type]).to be_nil
-      expect(comment.errors[:commentable_type]).to be_present
-      expect(comment.errors[:commentable_type]).to include("[AureliusPress::Document::Page] is not a commentable document type.")
+    it "creates a comment on a Page" do
+      comment = create(:aurelius_press_fragment_comment, :on_page, title: "Comment on a Page")
+      expect(comment).to be_persisted
+      expect(comment.commentable).to be_a(AureliusPress::Document::Page)
     end
 
     it "creates a BlogPost with 3 comments on it" do

--- a/spec/requests/aurelius_press/catalogue/comments_spec.rb
+++ b/spec/requests/aurelius_press/catalogue/comments_spec.rb
@@ -1,0 +1,162 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Catalogue::Comments", type: :request do
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:valid_params) { { comment: { content: "A thoughtful comment." } } }
+
+  # ── Author parent ──────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/catalogue/authors/:author_slug/comments" do
+    let(:author) { create(:aurelius_press_catalogue_author) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a comment on the author" do
+        expect {
+          post aurelius_press_catalogue_author_comments_path(author), params: valid_params
+        }.to change(AureliusPress::Fragment::Comment, :count).by(1)
+      end
+
+      it "associates the comment with the current user" do
+        post aurelius_press_catalogue_author_comments_path(author), params: valid_params
+        expect(AureliusPress::Fragment::Comment.last.user).to eq(owner)
+      end
+
+      it "redirects or returns turbo stream success" do
+        post aurelius_press_catalogue_author_comments_path(author), params: valid_params
+        expect(response).to have_http_status(:redirect).or have_http_status(:ok)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_catalogue_author_comments_path(author), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/catalogue/authors/:author_slug/comments/:id" do
+    let(:author)    { create(:aurelius_press_catalogue_author) }
+    let!(:comment)  { create(:aurelius_press_fragment_comment, user: owner, commentable: author) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the comment" do
+        expect {
+          delete aurelius_press_catalogue_author_comment_path(author, comment)
+        }.to change(AureliusPress::Fragment::Comment, :count).by(-1)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the comment" do
+        expect {
+          delete aurelius_press_catalogue_author_comment_path(author, comment)
+        }.not_to change(AureliusPress::Fragment::Comment, :count)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_catalogue_author_comment_path(author, comment)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── Source parent ──────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/catalogue/sources/:source_slug/comments" do
+    let(:source) { create(:aurelius_press_catalogue_source) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a comment on the source" do
+        expect {
+          post aurelius_press_catalogue_source_comments_path(source), params: valid_params
+        }.to change(AureliusPress::Fragment::Comment, :count).by(1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_catalogue_source_comments_path(source), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/catalogue/sources/:source_slug/comments/:id" do
+    let(:source)   { create(:aurelius_press_catalogue_source) }
+    let!(:comment) { create(:aurelius_press_fragment_comment, user: owner, commentable: source) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the comment" do
+        expect {
+          delete aurelius_press_catalogue_source_comment_path(source, comment)
+        }.to change(AureliusPress::Fragment::Comment, :count).by(-1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_catalogue_source_comment_path(source, comment)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── Quote parent ───────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/catalogue/quotes/:quote_slug/comments" do
+    let(:quote) { create(:aurelius_press_catalogue_quote) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a comment on the quote" do
+        expect {
+          post aurelius_press_catalogue_quote_comments_path(quote), params: valid_params
+        }.to change(AureliusPress::Fragment::Comment, :count).by(1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_catalogue_quote_comments_path(quote), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/catalogue/quotes/:quote_slug/comments/:id" do
+    let(:quote)    { create(:aurelius_press_catalogue_quote) }
+    let!(:comment) { create(:aurelius_press_fragment_comment, user: owner, commentable: quote) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the comment" do
+        expect {
+          delete aurelius_press_catalogue_quote_comment_path(quote, comment)
+        }.to change(AureliusPress::Fragment::Comment, :count).by(-1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_catalogue_quote_comment_path(quote, comment)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/aurelius_press/catalogue/notes_spec.rb
+++ b/spec/requests/aurelius_press/catalogue/notes_spec.rb
@@ -1,0 +1,157 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Catalogue::Notes", type: :request do
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:valid_params) { { note: { title: "My note", content: "Note body." } } }
+
+  # ── Author parent ──────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/catalogue/authors/:author_slug/notes" do
+    let(:author) { create(:aurelius_press_catalogue_author) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a note on the author" do
+        expect {
+          post aurelius_press_catalogue_author_notes_path(author), params: valid_params
+        }.to change(AureliusPress::Fragment::Note, :count).by(1)
+      end
+
+      it "associates the note with the current user" do
+        post aurelius_press_catalogue_author_notes_path(author), params: valid_params
+        expect(AureliusPress::Fragment::Note.last.user).to eq(owner)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_catalogue_author_notes_path(author), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/catalogue/authors/:author_slug/notes/:id" do
+    let(:author)  { create(:aurelius_press_catalogue_author) }
+    let!(:note)   { create(:aurelius_press_fragment_note, user: owner, notable: author) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the note" do
+        expect {
+          delete aurelius_press_catalogue_author_note_path(author, note)
+        }.to change(AureliusPress::Fragment::Note, :count).by(-1)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the note" do
+        expect {
+          delete aurelius_press_catalogue_author_note_path(author, note)
+        }.not_to change(AureliusPress::Fragment::Note, :count)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_catalogue_author_note_path(author, note)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── Source parent ──────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/catalogue/sources/:source_slug/notes" do
+    let(:source) { create(:aurelius_press_catalogue_source) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a note on the source" do
+        expect {
+          post aurelius_press_catalogue_source_notes_path(source), params: valid_params
+        }.to change(AureliusPress::Fragment::Note, :count).by(1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_catalogue_source_notes_path(source), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/catalogue/sources/:source_slug/notes/:id" do
+    let(:source) { create(:aurelius_press_catalogue_source) }
+    let!(:note)  { create(:aurelius_press_fragment_note, user: owner, notable: source) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the note" do
+        expect {
+          delete aurelius_press_catalogue_source_note_path(source, note)
+        }.to change(AureliusPress::Fragment::Note, :count).by(-1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_catalogue_source_note_path(source, note)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── Quote parent ───────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/catalogue/quotes/:quote_slug/notes" do
+    let(:quote) { create(:aurelius_press_catalogue_quote) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a note on the quote" do
+        expect {
+          post aurelius_press_catalogue_quote_notes_path(quote), params: valid_params
+        }.to change(AureliusPress::Fragment::Note, :count).by(1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_catalogue_quote_notes_path(quote), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/catalogue/quotes/:quote_slug/notes/:id" do
+    let(:quote) { create(:aurelius_press_catalogue_quote) }
+    let!(:note) { create(:aurelius_press_fragment_note, user: owner, notable: quote) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the note" do
+        expect {
+          delete aurelius_press_catalogue_quote_note_path(quote, note)
+        }.to change(AureliusPress::Fragment::Note, :count).by(-1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_catalogue_quote_note_path(quote, note)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/aurelius_press/document/comments_spec.rb
+++ b/spec/requests/aurelius_press/document/comments_spec.rb
@@ -1,0 +1,257 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Document::Comments", type: :request do
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+
+  # ── BlogPost parent ────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/blog-posts/:blog_post_id/comments" do
+    let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+    let(:valid_params) { { comment: { content: "A thoughtful comment." } } }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a comment on the blog post" do
+        expect {
+          post aurelius_press_blog_post_comments_path(blog_post), params: valid_params
+        }.to change(AureliusPress::Fragment::Comment, :count).by(1)
+      end
+
+      it "associates the comment with the current user" do
+        post aurelius_press_blog_post_comments_path(blog_post), params: valid_params
+        expect(AureliusPress::Fragment::Comment.last.user).to eq(owner)
+      end
+
+      it "redirects or returns turbo stream success" do
+        post aurelius_press_blog_post_comments_path(blog_post), params: valid_params
+        expect(response).to have_http_status(:redirect).or have_http_status(:ok)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_blog_post_comments_path(blog_post), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/blog-posts/:blog_post_id/comments/:id" do
+    let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+    let!(:comment)  { create(:aurelius_press_fragment_comment, :on_blog_post, user: owner, commentable: blog_post) }
+
+    context "when authenticated as the comment owner" do
+      before { sign_in owner }
+
+      it "destroys the comment" do
+        expect {
+          delete aurelius_press_blog_post_comment_path(blog_post, comment)
+        }.to change(AureliusPress::Fragment::Comment, :count).by(-1)
+      end
+
+      it "redirects or returns turbo stream success" do
+        delete aurelius_press_blog_post_comment_path(blog_post, comment)
+        expect(response).to have_http_status(:redirect).or have_http_status(:ok)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the comment" do
+        expect {
+          delete aurelius_press_blog_post_comment_path(blog_post, comment)
+        }.not_to change(AureliusPress::Fragment::Comment, :count)
+      end
+
+      it "returns forbidden or redirects" do
+        delete aurelius_press_blog_post_comment_path(blog_post, comment)
+        expect(response).to have_http_status(:forbidden).or have_http_status(:redirect)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_blog_post_comment_path(blog_post, comment)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── AtomicBlogPost parent ──────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/atomic-blog-posts/:atomic_blog_post_id/comments" do
+    let(:atomic_blog_post) { create(:aurelius_press_document_atomic_blog_post, :visible_to_www) }
+    let(:valid_params) { { comment: { content: "A thoughtful comment." } } }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a comment on the atomic blog post" do
+        expect {
+          post aurelius_press_atomic_blog_post_comments_path(atomic_blog_post), params: valid_params
+        }.to change(AureliusPress::Fragment::Comment, :count).by(1)
+      end
+
+      it "associates the comment with the current user" do
+        post aurelius_press_atomic_blog_post_comments_path(atomic_blog_post), params: valid_params
+        expect(AureliusPress::Fragment::Comment.last.user).to eq(owner)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_atomic_blog_post_comments_path(atomic_blog_post), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/atomic-blog-posts/:atomic_blog_post_id/comments/:id" do
+    let(:atomic_blog_post) { create(:aurelius_press_document_atomic_blog_post, :visible_to_www) }
+    let!(:comment) { create(:aurelius_press_fragment_comment, :on_atomic_blog_post, user: owner, commentable: atomic_blog_post) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the comment" do
+        expect {
+          delete aurelius_press_atomic_blog_post_comment_path(atomic_blog_post, comment)
+        }.to change(AureliusPress::Fragment::Comment, :count).by(-1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_atomic_blog_post_comment_path(atomic_blog_post, comment)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── Page parent (S2-03) ────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/pages/:page_id/comments" do
+    let(:page) { create(:aurelius_press_document_page, :visible_to_www) }
+    let(:valid_params) { { comment: { content: "A thoughtful comment." } } }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a comment on the page" do
+        expect {
+          post aurelius_press_page_comments_path(page), params: valid_params
+        }.to change(AureliusPress::Fragment::Comment, :count).by(1)
+      end
+
+      it "associates the comment with the current user" do
+        post aurelius_press_page_comments_path(page), params: valid_params
+        expect(AureliusPress::Fragment::Comment.last.user).to eq(owner)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_page_comments_path(page), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/pages/:page_id/comments/:id" do
+    let(:page) { create(:aurelius_press_document_page, :visible_to_www) }
+    let!(:comment) { create(:aurelius_press_fragment_comment, :on_page, user: owner, commentable: page) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the comment" do
+        expect {
+          delete aurelius_press_page_comment_path(page, comment)
+        }.to change(AureliusPress::Fragment::Comment, :count).by(-1)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the comment" do
+        expect {
+          delete aurelius_press_page_comment_path(page, comment)
+        }.not_to change(AureliusPress::Fragment::Comment, :count)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_page_comment_path(page, comment)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── ContentBlock parent (S2-09) ────────────────────────────────────────────
+
+  describe "POST /.../cb/:content_block_id/comments" do
+    let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+    let(:rich_text_block) do
+      create(:aurelius_press_content_block_rich_text_block, :attached_to_a, document_obj: blog_post)
+    end
+    let(:content_block) { rich_text_block.content_block }
+    let(:valid_params)  { { comment: { content: "A comment on a content block." } } }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a comment on the content block" do
+        expect {
+          post aurelius_press_blog_post_content_block_comments_path(blog_post, content_block),
+               params: valid_params
+        }.to change(AureliusPress::Fragment::Comment, :count).by(1)
+      end
+
+      it "associates the comment with the content block" do
+        post aurelius_press_blog_post_content_block_comments_path(blog_post, content_block),
+             params: valid_params
+        expect(AureliusPress::Fragment::Comment.last.commentable).to eq(content_block)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_blog_post_content_block_comments_path(blog_post, content_block),
+             params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /.../cb/:content_block_id/comments/:id" do
+    let(:blog_post)      { create(:aurelius_press_document_blog_post, :visible_to_www) }
+    let(:rich_text_block) do
+      create(:aurelius_press_content_block_rich_text_block, :attached_to_a, document_obj: blog_post)
+    end
+    let(:content_block) { rich_text_block.content_block }
+    let!(:comment) { create(:aurelius_press_fragment_comment, user: owner, commentable: content_block) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the comment" do
+        expect {
+          delete aurelius_press_blog_post_content_block_comment_path(blog_post, content_block, comment)
+        }.to change(AureliusPress::Fragment::Comment, :count).by(-1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_blog_post_content_block_comment_path(blog_post, content_block, comment)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+end

--- a/spec/requests/aurelius_press/document/content_block_notes_spec.rb
+++ b/spec/requests/aurelius_press/document/content_block_notes_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Document::ContentBlock Notes", type: :request do
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:blog_post)  { create(:aurelius_press_document_blog_post, :visible_to_www) }
+  let(:rich_text_block) do
+    create(:aurelius_press_content_block_rich_text_block, :attached_to_a, document_obj: blog_post)
+  end
+  let(:content_block) { rich_text_block.content_block }
+  let(:valid_params)  { { note: { title: "My note", content: "Note body." } } }
+
+  # ── POST /aurelius-press/blog-posts/:blog_post_id/cb/:content_block_id/notes ──
+
+  describe "POST /.../blog-posts/:blog_post_id/cb/:content_block_id/notes" do
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a note on the content block" do
+        expect {
+          post aurelius_press_blog_post_content_block_notes_path(blog_post, content_block),
+               params: valid_params
+        }.to change(AureliusPress::Fragment::Note, :count).by(1)
+      end
+
+      it "associates the note with the current user" do
+        post aurelius_press_blog_post_content_block_notes_path(blog_post, content_block),
+             params: valid_params
+        expect(AureliusPress::Fragment::Note.last.user).to eq(owner)
+      end
+
+      it "associates the note with the content block" do
+        post aurelius_press_blog_post_content_block_notes_path(blog_post, content_block),
+             params: valid_params
+        expect(AureliusPress::Fragment::Note.last.notable).to eq(content_block)
+      end
+
+      it "redirects or returns turbo stream success" do
+        post aurelius_press_blog_post_content_block_notes_path(blog_post, content_block),
+             params: valid_params
+        expect(response).to have_http_status(:redirect).or have_http_status(:ok)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_blog_post_content_block_notes_path(blog_post, content_block),
+             params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── DELETE /.../blog-posts/:blog_post_id/cb/:content_block_id/notes/:id ──
+
+  describe "DELETE /.../blog-posts/:blog_post_id/cb/:content_block_id/notes/:id" do
+    let!(:note) { create(:aurelius_press_fragment_note, user: owner, notable: content_block) }
+
+    context "when authenticated as the note owner" do
+      before { sign_in owner }
+
+      it "destroys the note" do
+        expect {
+          delete aurelius_press_blog_post_content_block_note_path(blog_post, content_block, note)
+        }.to change(AureliusPress::Fragment::Note, :count).by(-1)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the note" do
+        expect {
+          delete aurelius_press_blog_post_content_block_note_path(blog_post, content_block, note)
+        }.not_to change(AureliusPress::Fragment::Note, :count)
+      end
+
+      it "returns forbidden or redirects" do
+        delete aurelius_press_blog_post_content_block_note_path(blog_post, content_block, note)
+        expect(response).to have_http_status(:forbidden).or have_http_status(:redirect)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_blog_post_content_block_note_path(blog_post, content_block, note)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/aurelius_press/document/notes_spec.rb
+++ b/spec/requests/aurelius_press/document/notes_spec.rb
@@ -1,0 +1,182 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Document::Notes", type: :request do
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:valid_params) { { note: { title: "My note", content: "Note body." } } }
+
+  # ── BlogPost parent ────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/blog-posts/:blog_post_id/notes" do
+    let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a note on the blog post" do
+        expect {
+          post aurelius_press_blog_post_notes_path(blog_post), params: valid_params
+        }.to change(AureliusPress::Fragment::Note, :count).by(1)
+      end
+
+      it "associates the note with the current user" do
+        post aurelius_press_blog_post_notes_path(blog_post), params: valid_params
+        expect(AureliusPress::Fragment::Note.last.user).to eq(owner)
+      end
+
+      it "redirects or returns turbo stream success" do
+        post aurelius_press_blog_post_notes_path(blog_post), params: valid_params
+        expect(response).to have_http_status(:redirect).or have_http_status(:ok)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_blog_post_notes_path(blog_post), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/blog-posts/:blog_post_id/notes/:id" do
+    let(:blog_post) { create(:aurelius_press_document_blog_post, :visible_to_www) }
+    let!(:note) { create(:aurelius_press_fragment_note, user: owner, notable: blog_post) }
+
+    context "when authenticated as the note owner" do
+      before { sign_in owner }
+
+      it "destroys the note" do
+        expect {
+          delete aurelius_press_blog_post_note_path(blog_post, note)
+        }.to change(AureliusPress::Fragment::Note, :count).by(-1)
+      end
+
+      it "redirects or returns turbo stream success" do
+        delete aurelius_press_blog_post_note_path(blog_post, note)
+        expect(response).to have_http_status(:redirect).or have_http_status(:ok)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the note" do
+        expect {
+          delete aurelius_press_blog_post_note_path(blog_post, note)
+        }.not_to change(AureliusPress::Fragment::Note, :count)
+      end
+
+      it "returns forbidden or redirects" do
+        delete aurelius_press_blog_post_note_path(blog_post, note)
+        expect(response).to have_http_status(:forbidden).or have_http_status(:redirect)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_blog_post_note_path(blog_post, note)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── AtomicBlogPost parent ──────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/atomic-blog-posts/:atomic_blog_post_id/notes" do
+    let(:atomic_blog_post) { create(:aurelius_press_document_atomic_blog_post, :visible_to_www) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a note on the atomic blog post" do
+        expect {
+          post aurelius_press_atomic_blog_post_notes_path(atomic_blog_post), params: valid_params
+        }.to change(AureliusPress::Fragment::Note, :count).by(1)
+      end
+
+      it "associates the note with the current user" do
+        post aurelius_press_atomic_blog_post_notes_path(atomic_blog_post), params: valid_params
+        expect(AureliusPress::Fragment::Note.last.user).to eq(owner)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_atomic_blog_post_notes_path(atomic_blog_post), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/atomic-blog-posts/:atomic_blog_post_id/notes/:id" do
+    let(:atomic_blog_post) { create(:aurelius_press_document_atomic_blog_post, :visible_to_www) }
+    let!(:note) { create(:aurelius_press_fragment_note, user: owner, notable: atomic_blog_post) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the note" do
+        expect {
+          delete aurelius_press_atomic_blog_post_note_path(atomic_blog_post, note)
+        }.to change(AureliusPress::Fragment::Note, :count).by(-1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_atomic_blog_post_note_path(atomic_blog_post, note)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # ── Page parent ────────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/pages/:page_id/notes" do
+    let(:page) { create(:aurelius_press_document_page, :visible_to_www) }
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a note on the page" do
+        expect {
+          post aurelius_press_page_notes_path(page), params: valid_params
+        }.to change(AureliusPress::Fragment::Note, :count).by(1)
+      end
+
+      it "associates the note with the current user" do
+        post aurelius_press_page_notes_path(page), params: valid_params
+        expect(AureliusPress::Fragment::Note.last.user).to eq(owner)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_page_notes_path(page), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "DELETE /aurelius-press/pages/:page_id/notes/:id" do
+    let(:page) { create(:aurelius_press_document_page, :visible_to_www) }
+    let!(:note) { create(:aurelius_press_fragment_note, user: owner, notable: page) }
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the note" do
+        expect {
+          delete aurelius_press_page_note_path(page, note)
+        }.to change(AureliusPress::Fragment::Note, :count).by(-1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_page_note_path(page, note)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `AureliusPress::Document::CommentsController` and `NotesController` — single shared controllers handling BlogPost, AtomicBlogPost, Page, and ContentBlock parents
- Adds `AureliusPress::Catalogue::CommentsController` and `NotesController` — shared controllers for Author, Source, and Quote parents
- Turbo Stream templates (create / update / destroy) for all four controllers
- Shared `_form` partials under `aurelius_press/fragment/`
- `has_many :notes` added to Author, Source, Quote; `has_many :comments` added to ContentBlock
- Page added to `NAMESPACED_COMMENTABLE_TYPES`; ContentBlock added to Comment allowed types
- Direct `resources :comments` route added under pages

## Design decisions

- **Pages are commentable** — removed previous exclusion from `NAMESPACED_COMMENTABLE_TYPES`
- **ContentBlocks are commentable** — added association and allowlist entry

## Test plan

- [x] 95 new request specs across all controllers (0 failures)
- [x] Full suite: 269 examples, 0 failures
- [x] RuboCop clean
- [x] Brakeman clean

## Backlog coverage

Closes backlog items: 2.1–2.11, 2.13–2.18 (Sprint 2 P0 + P1 + P2)
Deferred to Sprint 3: 2.12 (inline ContentBlock views), 2.19 (catalogue views)