### PR TITLE
Sprint 3: JournalEntry, Group Memberships UI, catalogue views

### DIFF
--- a/app/controllers/aurelius_press/admin/community/groups_controller.rb
+++ b/app/controllers/aurelius_press/admin/community/groups_controller.rb
@@ -1,5 +1,5 @@
 class AureliusPress::Admin::Community::GroupsController < AureliusPress::Admin::ApplicationController
-  before_action :set_group, only: [:show, :edit, :update, :destroy]
+  before_action :set_group, only: [ :show, :edit, :update, :destroy ]
 
   def index
     @groups = AureliusPress::Community::Group.all
@@ -46,7 +46,7 @@ class AureliusPress::Admin::Community::GroupsController < AureliusPress::Admin::
   private
 
   def set_group
-    @group = AureliusPress::Community::Group.find(params[:id])
+    @group = AureliusPress::Community::Group.find_by!(slug: params[:id])
   end
 
   def group_params

--- a/app/controllers/aurelius_press/community/group_memberships_controller.rb
+++ b/app/controllers/aurelius_press/community/group_memberships_controller.rb
@@ -1,0 +1,38 @@
+class AureliusPress::Community::GroupMembershipsController < AureliusPress::ApplicationController
+  before_action :set_membership, only: %i[destroy]
+
+  def create
+    @group = AureliusPress::Community::Group.find(params[:group_membership][:group_id])
+    @membership = @group.group_memberships.build(user: current_user, role: :member, status: :active)
+    authorize @membership, :create?, policy_class: AureliusPress::Community::GroupMembershipPolicy
+
+    if @membership.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path, notice: "You joined the group." }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("flash", partial: "shared/flash") }
+        format.html { redirect_back fallback_location: root_path, alert: @membership.errors.full_messages.to_sentence }
+      end
+    end
+  end
+
+  def destroy
+    authorize @membership, :destroy?, policy_class: AureliusPress::Community::GroupMembershipPolicy
+    @group = @membership.group
+    @membership.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path, notice: "You left the group." }
+    end
+  end
+
+  private
+
+  def set_membership
+    @membership = AureliusPress::Community::GroupMembership.find(params[:id])
+  end
+end

--- a/app/controllers/aurelius_press/community/groups_controller.rb
+++ b/app/controllers/aurelius_press/community/groups_controller.rb
@@ -1,0 +1,20 @@
+class AureliusPress::Community::GroupsController < AureliusPress::ApplicationController
+  before_action :set_group, only: %i[show]
+
+  def index
+    authorize AureliusPress::Community::Group, :index?, policy_class: AureliusPress::Community::GroupPolicy
+    @groups = AureliusPress::Community::Group.where(privacy_setting: :public_group).order(:name)
+  end
+
+  def show
+    authorize @group, :show?, policy_class: AureliusPress::Community::GroupPolicy
+    @members = @group.members
+    @membership = @group.group_memberships.find_by(user: current_user)
+  end
+
+  private
+
+  def set_group
+    @group = AureliusPress::Community::Group.find_by!(slug: params[:slug])
+  end
+end

--- a/app/controllers/aurelius_press/document/journal_entries_controller.rb
+++ b/app/controllers/aurelius_press/document/journal_entries_controller.rb
@@ -59,7 +59,35 @@ class AureliusPress::Document::JournalEntriesController < AureliusPress::Applica
       :description,
       :status,
       :comments_enabled,
-      category_ids: []
+      category_ids: [],
+      content_blocks_attributes: [
+        :id,
+        :_destroy,
+        :contentable_id,
+        :contentable_type,
+        :position,
+        :html_id,
+        :html_class,
+        :data_attributes,
+        contentable_attributes: [
+          :id,
+          :type,
+          :content,
+          :image,
+          :caption,
+          :alignment,
+          :link_text,
+          :link_title,
+          :link_class,
+          :link_target,
+          :link_url,
+          :embed_code,
+          :description,
+          :video_url,
+          :layout_type,
+          images: []
+        ]
+      ]
     )
   end
 end

--- a/app/controllers/aurelius_press/document/journal_entries_controller.rb
+++ b/app/controllers/aurelius_press/document/journal_entries_controller.rb
@@ -1,0 +1,65 @@
+class AureliusPress::Document::JournalEntriesController < AureliusPress::ApplicationController
+  before_action :set_journal_entry, only: %i[show edit update destroy]
+
+  def index
+    authorize AureliusPress::Document::JournalEntry, :index?, policy_class: AureliusPress::DocumentPolicy
+    @journal_entries = AureliusPress::Document::JournalEntry.where(user: current_user).recent
+  end
+
+  def show
+    authorize @journal_entry, :show?, policy_class: AureliusPress::DocumentPolicy
+  end
+
+  def new
+    @journal_entry = AureliusPress::Document::JournalEntry.new
+    authorize @journal_entry, :new?, policy_class: AureliusPress::DocumentPolicy
+  end
+
+  def create
+    @journal_entry = AureliusPress::Document::JournalEntry.new(journal_entry_params.merge(user: current_user, visibility: :private_to_owner))
+    authorize @journal_entry, :create?, policy_class: AureliusPress::DocumentPolicy
+
+    if @journal_entry.save
+      redirect_to aurelius_press_journal_entry_path(@journal_entry), notice: "Journal entry created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    authorize @journal_entry, :edit?, policy_class: AureliusPress::DocumentPolicy
+  end
+
+  def update
+    authorize @journal_entry, :update?, policy_class: AureliusPress::DocumentPolicy
+
+    if @journal_entry.update(journal_entry_params)
+      redirect_to aurelius_press_journal_entry_path(@journal_entry), notice: "Journal entry updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    authorize @journal_entry, :destroy?, policy_class: AureliusPress::DocumentPolicy
+    @journal_entry.destroy
+    redirect_to aurelius_press_journal_entries_path, notice: "Journal entry deleted."
+  end
+
+  private
+
+  def set_journal_entry
+    @journal_entry = AureliusPress::Document::JournalEntry.find_by!(slug: params[:id])
+  end
+
+  def journal_entry_params
+    params.require(:aurelius_press_document_journal_entry).permit(
+      :title,
+      :subtitle,
+      :description,
+      :status,
+      :comments_enabled,
+      category_ids: []
+    )
+  end
+end

--- a/app/models/aurelius_press/community/group.rb
+++ b/app/models/aurelius_press/community/group.rb
@@ -41,6 +41,10 @@ class AureliusPress::Community::Group < ApplicationRecord
          hidden_group
        ], default: :private_group
 
+  def to_param
+    slug
+  end
+
   # Validations
   validates :name, presence: true, uniqueness: { case_insensitive: true }, length: { maximum: 100 }
   validates :description, length: { maximum: 1000 }, allow_blank: true

--- a/app/models/aurelius_press/document/journal_entry.rb
+++ b/app/models/aurelius_press/document/journal_entry.rb
@@ -23,7 +23,11 @@ class AureliusPress::Document::JournalEntry < AureliusPress::Document::Document
   # Callbacks
   after_initialize :set_defaults, if: :new_record?
 
-  # Validations @see: Document
+  # Validations
+  validates :visibility, inclusion: {
+    in: %w[private_to_owner],
+    message: "Journal entries must always be private."
+  }
 
   private
 

--- a/app/views/aurelius_press/catalogue/authors/show.html.erb
+++ b/app/views/aurelius_press/catalogue/authors/show.html.erb
@@ -21,4 +21,9 @@
     <%= render "aurelius_press/taxonomy/shared/labels", interactable: @author %>
   </div>
 
+  <%= render partial: "aurelius_press/catalogue/shared/comments_and_notes",
+             locals: { resource: @author,
+                       comments_path: aurelius_press_catalogue_author_comments_path(@author),
+                       notes_path: aurelius_press_catalogue_author_notes_path(@author) } %>
+
 </div>

--- a/app/views/aurelius_press/catalogue/quotes/show.html.erb
+++ b/app/views/aurelius_press/catalogue/quotes/show.html.erb
@@ -23,4 +23,9 @@
   <p><strong>Created At:</strong> <%= l(@quote.created_at, format: :long) %></p>
   <p><strong>Updated At:</strong> <%= l(@quote.updated_at, format: :long) %></p>
 
+  <%= render partial: "aurelius_press/catalogue/shared/comments_and_notes",
+             locals: { resource: @quote,
+                       comments_path: aurelius_press_catalogue_quote_comments_path(@quote),
+                       notes_path: aurelius_press_catalogue_quote_notes_path(@quote) } %>
+
 </div>

--- a/app/views/aurelius_press/catalogue/shared/_comments_and_notes.html.erb
+++ b/app/views/aurelius_press/catalogue/shared/_comments_and_notes.html.erb
@@ -1,0 +1,40 @@
+<%# Locals: resource (Author/Source/Quote), comments_path:, notes_path: %>
+<div class="catalogue-engagement" id="<%= dom_id(resource, :engagement) %>">
+
+  <%# Comments %>
+  <section id="<%= dom_id(resource, :comments) %>" class="comments-section">
+    <h3>Comments (<%= resource.comments.count %>)</h3>
+
+    <div class="comments-list">
+      <%= render partial: "aurelius_press/fragment/comments/comment",
+                 collection: resource.comments.includes(:user),
+                 as: :comment %>
+    </div>
+
+    <% if user_signed_in? %>
+      <%= render partial: "aurelius_press/fragment/comments/form",
+                 locals: { comment: AureliusPress::Fragment::Comment.new,
+                           commentable: resource,
+                           url: comments_path } %>
+    <% end %>
+  </section>
+
+  <%# Notes (owner-only) %>
+  <% if user_signed_in? %>
+    <section id="<%= dom_id(resource, :notes) %>" class="notes-section">
+      <h3>My Notes (<%= resource.notes.where(user: current_user).count %>)</h3>
+
+      <div class="notes-list">
+        <%= render partial: "aurelius_press/fragment/notes/note",
+                   collection: resource.notes.where(user: current_user).includes(:user),
+                   as: :note %>
+      </div>
+
+      <%= render partial: "aurelius_press/fragment/notes/form",
+                 locals: { note: AureliusPress::Fragment::Note.new,
+                           notable: resource,
+                           url: notes_path } %>
+    </section>
+  <% end %>
+
+</div>

--- a/app/views/aurelius_press/catalogue/sources/show.html.erb
+++ b/app/views/aurelius_press/catalogue/sources/show.html.erb
@@ -22,4 +22,9 @@
 
   <p><strong>Updated At:</strong> <%= l(@source.updated_at, format: :long) %></p>
 
+  <%= render partial: "aurelius_press/catalogue/shared/comments_and_notes",
+             locals: { resource: @source,
+                       comments_path: aurelius_press_catalogue_source_comments_path(@source),
+                       notes_path: aurelius_press_catalogue_source_notes_path(@source) } %>
+
 </div>

--- a/app/views/aurelius_press/community/group_memberships/create.turbo_stream.erb
+++ b/app/views/aurelius_press/community/group_memberships/create.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.replace dom_id(@group, :membership_button) do %>
+  <%= render partial: "aurelius_press/community/groups/membership_button",
+             locals: { group: @group, membership: @membership } %>
+<% end %>

--- a/app/views/aurelius_press/community/group_memberships/destroy.turbo_stream.erb
+++ b/app/views/aurelius_press/community/group_memberships/destroy.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.replace dom_id(@group, :membership_button) do %>
+  <%= render partial: "aurelius_press/community/groups/membership_button",
+             locals: { group: @group, membership: nil } %>
+<% end %>

--- a/app/views/aurelius_press/community/groups/_membership_button.html.erb
+++ b/app/views/aurelius_press/community/groups/_membership_button.html.erb
@@ -1,0 +1,12 @@
+<span id="<%= dom_id(group, :membership_button) %>">
+  <% if membership %>
+    <%= button_to "Leave Group",
+                  aurelius_press_community_group_membership_path(membership),
+                  method: :delete,
+                  data: { turbo_confirm: "Leave this group?" } %>
+  <% elsif user_signed_in? %>
+    <%= button_to "Join Group",
+                  aurelius_press_community_group_memberships_path,
+                  params: { group_membership: { group_id: group.id } } %>
+  <% end %>
+</span>

--- a/app/views/aurelius_press/community/groups/index.html.erb
+++ b/app/views/aurelius_press/community/groups/index.html.erb
@@ -1,0 +1,11 @@
+<div class="container">
+  <h1>Groups</h1>
+
+  <% @groups.each do |group| %>
+    <div id="<%= dom_id(group) %>">
+      <h2><%= link_to group.name, aurelius_press_community_group_path(group) %></h2>
+      <p><%= group.description %></p>
+      <p><%= group.members.count %> members</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/aurelius_press/community/groups/show.html.erb
+++ b/app/views/aurelius_press/community/groups/show.html.erb
@@ -1,0 +1,15 @@
+<div class="container">
+  <h1><%= @group.name %></h1>
+  <p><%= @group.description %></p>
+
+  <%= render "membership_button", group: @group, membership: @membership %>
+
+  <h2>Members (<%= @members.count %>)</h2>
+  <ul>
+    <% @members.each do |member| %>
+      <li><%= member.email %></li>
+    <% end %>
+  </ul>
+
+  <%= link_to "Back to Groups", aurelius_press_community_groups_path %>
+</div>

--- a/app/views/aurelius_press/content_block/shared/_comments_panel.html.erb
+++ b/app/views/aurelius_press/content_block/shared/_comments_panel.html.erb
@@ -1,0 +1,19 @@
+<%# Locals: content_block (ContentBlock), comments_path (String — POST URL for new comments) %>
+<section class="content-block-comments" id="<%= dom_id(content_block, :comments) %>">
+  <h4>Comments (<%= content_block.comments.count %>)</h4>
+
+  <div class="comments-list">
+    <%= render partial: "aurelius_press/fragment/comments/comment",
+               collection: content_block.comments.includes(:user),
+               as: :comment %>
+  </div>
+
+  <% if user_signed_in? %>
+    <div class="comment-form">
+      <%= render partial: "aurelius_press/fragment/comments/form",
+                 locals: { comment: AureliusPress::Fragment::Comment.new,
+                           commentable: content_block,
+                           url: comments_path } %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/aurelius_press/content_block/shared/_notes_panel.html.erb
+++ b/app/views/aurelius_press/content_block/shared/_notes_panel.html.erb
@@ -1,0 +1,19 @@
+<%# Locals: content_block (ContentBlock), notes_path (String — POST URL for new notes) %>
+<section class="content-block-notes" id="<%= dom_id(content_block, :notes) %>">
+  <h4>Notes (<%= content_block.notes.count %>)</h4>
+
+  <div class="notes-list">
+    <%= render partial: "aurelius_press/fragment/notes/note",
+               collection: content_block.notes.includes(:user),
+               as: :note %>
+  </div>
+
+  <% if user_signed_in? %>
+    <div class="note-form">
+      <%= render partial: "aurelius_press/fragment/notes/form",
+                 locals: { note: AureliusPress::Fragment::Note.new,
+                           notable: content_block,
+                           url: notes_path } %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/aurelius_press/document/journal_entries/_form.html.erb
+++ b/app/views/aurelius_press/document/journal_entries/_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_with model: journal_entry,
+              url: journal_entry.new_record? ? aurelius_press_journal_entries_path : aurelius_press_journal_entry_path(journal_entry),
+              method: journal_entry.new_record? ? :post : :patch do |f| %>
+  <% if journal_entry.errors.any? %>
+    <div id="error_explanation">
+      <ul>
+        <% journal_entry.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= f.label :subtitle %>
+    <%= f.text_field :subtitle %>
+  </div>
+
+  <div class="field">
+    <%= f.label :description %>
+    <%= f.text_area :description, rows: 10 %>
+  </div>
+
+  <div class="field">
+    <%= f.label :status %>
+    <%= f.select :status, AureliusPress::Document::Document.statuses.keys.map { |s| [s.humanize, s] } %>
+  </div>
+
+  <div class="field">
+    <%= f.label :comments_enabled %>
+    <%= f.check_box :comments_enabled %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/aurelius_press/document/journal_entries/edit.html.erb
+++ b/app/views/aurelius_press/document/journal_entries/edit.html.erb
@@ -1,0 +1,5 @@
+<div class="container">
+  <h1>Edit Journal Entry</h1>
+  <%= render "form", journal_entry: @journal_entry %>
+  <%= link_to "Back", aurelius_press_journal_entry_path(@journal_entry) %>
+</div>

--- a/app/views/aurelius_press/document/journal_entries/index.html.erb
+++ b/app/views/aurelius_press/document/journal_entries/index.html.erb
@@ -1,0 +1,32 @@
+<div class="container">
+  <h1>My Journal</h1>
+
+  <div class="page-links">
+    <%= link_to "New Entry", new_aurelius_press_journal_entry_path %>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Status</th>
+        <th>Created</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @journal_entries.each do |entry| %>
+        <tr>
+          <td><%= entry.title %></td>
+          <td><%= entry.status %></td>
+          <td><%= entry.created_at.strftime("%Y-%m-%d") %></td>
+          <td>
+            <%= link_to "Show", aurelius_press_journal_entry_path(entry) %>
+            <%= link_to "Edit", edit_aurelius_press_journal_entry_path(entry) %>
+            <%= link_to "Delete", aurelius_press_journal_entry_path(entry), data: { turbo_method: :delete, turbo_confirm: "Delete this entry?" } %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/aurelius_press/document/journal_entries/new.html.erb
+++ b/app/views/aurelius_press/document/journal_entries/new.html.erb
@@ -1,0 +1,5 @@
+<div class="container">
+  <h1>New Journal Entry</h1>
+  <%= render "form", journal_entry: @journal_entry %>
+  <%= link_to "Back to Journal", aurelius_press_journal_entries_path %>
+</div>

--- a/app/views/aurelius_press/document/journal_entries/show.html.erb
+++ b/app/views/aurelius_press/document/journal_entries/show.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+  <h1><%= @journal_entry.title %></h1>
+  <% if @journal_entry.subtitle.present? %>
+    <h2><%= @journal_entry.subtitle %></h2>
+  <% end %>
+
+  <p><%= @journal_entry.description %></p>
+
+  <div class="actions">
+    <%= link_to "Edit", edit_aurelius_press_journal_entry_path(@journal_entry) %>
+    <%= link_to "Delete", aurelius_press_journal_entry_path(@journal_entry), data: { turbo_method: :delete, turbo_confirm: "Delete this entry?" } %>
+    <%= link_to "Back to Journal", aurelius_press_journal_entries_path %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,8 @@ Rails.application.routes.draw do
     namespace :community do
       resources :reactions, only: [ :create, :destroy, :update ]
       resources :likes, only: [ :create, :destroy, :update ]
+      resources :group_memberships, path: "group-memberships", only: [ :create, :destroy ]
+      resources :groups, only: [ :index, :show ], param: :slug
     end
     # Define routes for users
     resources :users, only: [ :show, :edit, :update ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,8 @@ Rails.application.routes.draw do
         resources :comments, only: [ :create, :update, :destroy ]
       end
     end
+    # Define routes for Journal Entries (always private, owner-only)
+    resources :journal_entries, path: "journal-entries", module: "document"
     # Define routes for Pages
     resources :pages, module: "document" do
       resources :content_blocks, path: "cb", only: [ :create, :update, :destroy ] do

--- a/spec/models/aurelius_press/document/journal_entry_spec.rb
+++ b/spec/models/aurelius_press/document/journal_entry_spec.rb
@@ -20,7 +20,20 @@
 require "rails_helper"
 
 RSpec.describe AureliusPress::Document::JournalEntry, type: :model do
-  subject { create(:aurelius_press_document_journal_entry, :with_belt_and_braces) }
+  subject do
+    create(:aurelius_press_document_journal_entry,
+           :published_1_month_ago,
+           :with_content_blocks,
+           :with_category,
+           :with_tags,
+           :with_3x3x3_comments,
+           :with_notes,
+           :with_likes,
+           subtitle: Faker::Lorem.sentence(word_count: 5),
+           description: Faker::Lorem.paragraph(sentence_count: 3),
+           comments_enabled: true,
+           visibility: :private_to_owner)
+  end
 
   it "is a valid JournalEntry" do
     expect(subject).to be_valid
@@ -41,7 +54,7 @@ RSpec.describe AureliusPress::Document::JournalEntry, type: :model do
     expect(subject.subtitle).to be_present
     expect(subject.description).to be_present
     expect(subject.status).to eq("published")
-    expect(subject.visibility).to eq("public_to_www")
+    expect(subject.visibility).to eq("private_to_owner")
     expect(subject.published_at).to be_present
     expect(subject.published_at).to be < Time.current
     expect(subject.user).to be_present

--- a/spec/requests/aurelius_press/community/group_memberships_spec.rb
+++ b/spec/requests/aurelius_press/community/group_memberships_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Community::GroupMemberships", type: :request do
+  let(:user)       { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let(:group)      { create(:aurelius_press_community_group) }
+
+  # ── Create (join) ──────────────────────────────────────────────────────────
+
+  describe "POST /aurelius-press/community/group-memberships (create)" do
+    let(:valid_params) { { group_membership: { group_id: group.id } } }
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_community_group_memberships_path, params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "creates a group membership" do
+        expect {
+          post aurelius_press_community_group_memberships_path, params: valid_params
+        }.to change(AureliusPress::Community::GroupMembership, :count).by(1)
+      end
+
+      it "associates the membership with current_user" do
+        post aurelius_press_community_group_memberships_path, params: valid_params
+        expect(AureliusPress::Community::GroupMembership.last.user).to eq(user)
+      end
+
+      it "responds with turbo stream or redirect" do
+        post aurelius_press_community_group_memberships_path, params: valid_params
+        expect(response).to have_http_status(:ok).or redirect_to(anything)
+      end
+
+      context "when already a member" do
+        before { create(:aurelius_press_community_group_membership, group: group, user: user) }
+
+        it "does not create a duplicate membership" do
+          expect {
+            post aurelius_press_community_group_memberships_path, params: valid_params
+          }.not_to change(AureliusPress::Community::GroupMembership, :count)
+        end
+      end
+    end
+  end
+
+  # ── Destroy (leave) ────────────────────────────────────────────────────────
+
+  describe "DELETE /aurelius-press/community/group-memberships/:id (destroy)" do
+    let!(:membership) { create(:aurelius_press_community_group_membership, group: group, user: user) }
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_community_group_membership_path(membership)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as the member" do
+      before { sign_in user }
+
+      it "destroys the membership" do
+        expect {
+          delete aurelius_press_community_group_membership_path(membership)
+        }.to change(AureliusPress::Community::GroupMembership, :count).by(-1)
+      end
+
+      it "responds with turbo stream or redirect" do
+        delete aurelius_press_community_group_membership_path(membership)
+        expect(response).to have_http_status(:ok).or redirect_to(anything)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the membership" do
+        expect {
+          delete aurelius_press_community_group_membership_path(membership)
+        }.not_to change(AureliusPress::Community::GroupMembership, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/aurelius_press/community/groups_spec.rb
+++ b/spec/requests/aurelius_press/community/groups_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Community::Groups", type: :request do
+  let(:user)    { create(:aurelius_press_user) }
+  let!(:public_group)  { create(:aurelius_press_community_group) }
+  let!(:private_group) { create(:aurelius_press_community_group, :private_group) }
+
+  # ── Index ──────────────────────────────────────────────────────────────────
+
+  describe "GET /aurelius-press/community/groups (index)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        get aurelius_press_community_groups_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "returns http success" do
+        get aurelius_press_community_groups_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "lists public groups" do
+        get aurelius_press_community_groups_path
+        expect(response.body).to include(public_group.name)
+      end
+    end
+  end
+
+  # ── Show ───────────────────────────────────────────────────────────────────
+
+  describe "GET /aurelius-press/community/groups/:slug (show)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        get aurelius_press_community_group_path(public_group)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "returns http success for a public group" do
+        get aurelius_press_community_group_path(public_group)
+        expect(response).to have_http_status(:success)
+      end
+
+      it "lists group members" do
+        member = create(:aurelius_press_user)
+        create(:aurelius_press_community_group_membership, group: public_group, user: member)
+        get aurelius_press_community_group_path(public_group)
+        expect(response.body).to include(member.email)
+      end
+    end
+  end
+end

--- a/spec/requests/aurelius_press/document/journal_entries_spec.rb
+++ b/spec/requests/aurelius_press/document/journal_entries_spec.rb
@@ -1,0 +1,225 @@
+require "rails_helper"
+
+RSpec.describe "AureliusPress::Document::JournalEntries", type: :request do
+  let(:owner)      { create(:aurelius_press_user) }
+  let(:other_user) { create(:aurelius_press_user) }
+  let!(:entry)     { create(:aurelius_press_document_journal_entry, user: owner) }
+  let(:valid_params) do
+    { aurelius_press_document_journal_entry: { title: "My private thoughts", description: "Some content." } }
+  end
+
+  # ── Authentication gate ────────────────────────────────────────────────────
+
+  describe "GET /aurelius-press/journal-entries (index)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        get aurelius_press_journal_entries_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "returns http success" do
+        get aurelius_press_journal_entries_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "only shows own entries" do
+        other_entry = create(:aurelius_press_document_journal_entry, user: other_user)
+        get aurelius_press_journal_entries_path
+        expect(response.body).to include(entry.title)
+        expect(response.body).not_to include(other_entry.title)
+      end
+    end
+  end
+
+  # ── Show ───────────────────────────────────────────────────────────────────
+
+  describe "GET /aurelius-press/journal-entries/:id (show)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        get aurelius_press_journal_entry_path(entry)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "returns http success" do
+        get aurelius_press_journal_entry_path(entry)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not return the entry (forbidden or redirect)" do
+        get aurelius_press_journal_entry_path(entry)
+        expect(response).not_to have_http_status(:success)
+      end
+    end
+  end
+
+  # ── New / Create ───────────────────────────────────────────────────────────
+
+  describe "GET /aurelius-press/journal-entries/new (new)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        get new_aurelius_press_journal_entry_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "returns http success" do
+        get new_aurelius_press_journal_entry_path
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "POST /aurelius-press/journal-entries (create)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        post aurelius_press_journal_entries_path, params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in owner }
+
+      it "creates a new journal entry" do
+        expect {
+          post aurelius_press_journal_entries_path, params: valid_params
+        }.to change(AureliusPress::Document::JournalEntry, :count).by(1)
+      end
+
+      it "sets the entry owner to current_user" do
+        post aurelius_press_journal_entries_path, params: valid_params
+        expect(AureliusPress::Document::JournalEntry.last.user).to eq(owner)
+      end
+
+      it "enforces private_to_owner visibility regardless of submitted params" do
+        params_with_public = valid_params.deep_merge(
+          aurelius_press_document_journal_entry: { visibility: :public_to_www }
+        )
+        post aurelius_press_journal_entries_path, params: params_with_public
+        expect(AureliusPress::Document::JournalEntry.last.visibility).to eq("private_to_owner")
+      end
+
+      it "redirects to the created entry" do
+        post aurelius_press_journal_entries_path, params: valid_params
+        expect(response).to redirect_to(aurelius_press_journal_entry_path(AureliusPress::Document::JournalEntry.last))
+      end
+    end
+  end
+
+  # ── Edit / Update ──────────────────────────────────────────────────────────
+
+  describe "GET /aurelius-press/journal-entries/:id/edit (edit)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        get edit_aurelius_press_journal_entry_path(entry)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "returns http success" do
+        get edit_aurelius_press_journal_entry_path(entry)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "is forbidden" do
+        get edit_aurelius_press_journal_entry_path(entry)
+        expect(response).not_to have_http_status(:success)
+      end
+    end
+  end
+
+  describe "PATCH /aurelius-press/journal-entries/:id (update)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        patch aurelius_press_journal_entry_path(entry),
+              params: { aurelius_press_document_journal_entry: { title: "Updated" } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "updates the entry" do
+        patch aurelius_press_journal_entry_path(entry),
+              params: { aurelius_press_document_journal_entry: { title: "Updated Title" } }
+        expect(entry.reload.title).to eq("Updated Title")
+      end
+
+      it "redirects to the entry" do
+        patch aurelius_press_journal_entry_path(entry),
+              params: { aurelius_press_document_journal_entry: { title: "Updated Title" } }
+        expect(response).to redirect_to(aurelius_press_journal_entry_path(entry.reload))
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "is forbidden" do
+        patch aurelius_press_journal_entry_path(entry),
+              params: { aurelius_press_document_journal_entry: { title: "Hijacked" } }
+        expect(response).not_to have_http_status(:success)
+        expect(entry.reload.title).not_to eq("Hijacked")
+      end
+    end
+  end
+
+  # ── Destroy ────────────────────────────────────────────────────────────────
+
+  describe "DELETE /aurelius-press/journal-entries/:id (destroy)" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        delete aurelius_press_journal_entry_path(entry)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "destroys the entry" do
+        expect {
+          delete aurelius_press_journal_entry_path(entry)
+        }.to change(AureliusPress::Document::JournalEntry, :count).by(-1)
+      end
+
+      it "redirects to the index" do
+        delete aurelius_press_journal_entry_path(entry)
+        expect(response).to redirect_to(aurelius_press_journal_entries_path)
+      end
+    end
+
+    context "when authenticated as a different user" do
+      before { sign_in other_user }
+
+      it "does not destroy the entry" do
+        expect {
+          delete aurelius_press_journal_entry_path(entry)
+        }.not_to change(AureliusPress::Document::JournalEntry, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/aurelius_press/document/journal_entry_content_blocks_spec.rb
+++ b/spec/requests/aurelius_press/document/journal_entry_content_blocks_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe "JournalEntry ContentBlocks", type: :request do
+  let(:owner) { create(:aurelius_press_user) }
+  let!(:entry) { create(:aurelius_press_document_journal_entry, user: owner) }
+  let(:rich_text_block_attributes) do
+    {
+      "0" => {
+        position: 1,
+        contentable_type: "AureliusPress::ContentBlock::RichTextBlock",
+        contentable_attributes: { content: "My journal thought." }
+      }
+    }
+  end
+
+  describe "PATCH /aurelius-press/journal-entries/:id (update with content blocks)" do
+    context "when authenticated as owner" do
+      before { sign_in owner }
+
+      it "creates a nested content block" do
+        expect {
+          patch aurelius_press_journal_entry_path(entry),
+                params: {
+                  aurelius_press_document_journal_entry: {
+                    content_blocks_attributes: rich_text_block_attributes
+                  }
+                }
+        }.to change(AureliusPress::ContentBlock::ContentBlock, :count).by(1)
+      end
+
+      it "associates the content block with the journal entry" do
+        patch aurelius_press_journal_entry_path(entry),
+              params: {
+                aurelius_press_document_journal_entry: {
+                  content_blocks_attributes: rich_text_block_attributes
+                }
+              }
+        expect(entry.reload.content_blocks.count).to eq(1)
+      end
+    end
+
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        patch aurelius_press_journal_entry_path(entry),
+              params: {
+                aurelius_press_document_journal_entry: {
+                  content_blocks_attributes: rich_text_block_attributes
+                }
+              }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `AureliusPress::Document::JournalEntriesController` — full CRUD, always-private enforced (visibility locked to `private_to_owner` at model + controller level)
- `AureliusPress::Community::GroupMembershipsController` — create (join) / destroy (leave) with Turbo Stream toggle
- `AureliusPress::Community::GroupsController` — public index (public groups only) + show (members list)
- JournalEntry content blocks — `content_blocks_attributes` permitted in controller params
- Catalogue show pages (Author, Source, Quote) now render inline comments + owner-scoped notes
- Content block shared partials (`_comments_panel`, `_notes_panel`) for embedding in block views
- `Group#to_param` added for slug-based URL generation; admin groups controller updated to match

## Design decisions

- **JournalEntry is always private** — validation + controller enforce `private_to_owner` regardless of submitted params
- **Group discovery shows public groups only** — `privacy_setting: :public_group` scope on index; show respects existing `GroupPolicy#show?`
- **Catalogue notes are owner-scoped** — the shared partial renders only `current_user`'s notes on catalogue resources

## Test plan

- [x] 54 new request specs (journal entries, group memberships, groups, content blocks)
- [x] Full suite: 728 examples, 0 failures
- [x] JournalEntry model spec updated to reflect always-private constraint
- [x] RuboCop clean
- [x] Brakeman clean

## Backlog coverage

Closes: 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, 4.5, 2.12, 2.19